### PR TITLE
Feature signUp and signIn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/challenger/fridge/FridgeApplication.java
+++ b/src/main/java/com/challenger/fridge/FridgeApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
-//@ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.challenger\\.fridge\\.util\\..*"))
+@SpringBootApplication
+@ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.challenger\\.fridge\\.util\\..*"))
 public class FridgeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/challenger/fridge/common/MemberRole.java
+++ b/src/main/java/com/challenger/fridge/common/MemberRole.java
@@ -1,5 +1,5 @@
 package com.challenger.fridge.common;
 
-public enum MemberType {
-    USER
+public enum MemberRole {
+    ROLE_USER
 }

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -25,7 +25,13 @@ public class SignController {
     @Operation(summary = "회원 이메일 중복 체크")
     @GetMapping("/sign-up")
     public ApiResponse checkEmail(@RequestBody String email) {
-        return ApiResponse.success(signService.checkDuplicateEmail(email));
+//        return ApiResponse.success(signService.checkDuplicateEmail(email));
+        boolean result = signService.checkDuplicateEmail(email);
+        if (result) {
+            return ApiResponse.error("사용중인 이메일입니다. 다시 입력해주세요");
+        } else {
+            return ApiResponse.success(null);
+        }
     }
 
     @Operation(summary = "회원가입")

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -1,0 +1,30 @@
+package com.challenger.fridge.controller;
+
+import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.service.SignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class SignController {
+
+    private final SignService signService;
+
+    @GetMapping("/sign-up")
+    public ApiResponse checkEmail(@RequestBody String email) {
+        return ApiResponse.success(signService.checkDuplicateEmail(email));
+    }
+
+    @PostMapping("/sign-up")
+    public ApiResponse signUp(@RequestBody SignUpRequest request) {
+        return ApiResponse.success(signService.registerMember(request));
+    }
+}

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -1,8 +1,11 @@
 package com.challenger.fridge.controller;
 
 import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.sign.SignInRequest;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.service.SignService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "회원가입 및 로그인")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
@@ -18,13 +22,21 @@ public class SignController {
 
     private final SignService signService;
 
+    @Operation(summary = "회원 이메일 중복 체크")
     @GetMapping("/sign-up")
     public ApiResponse checkEmail(@RequestBody String email) {
         return ApiResponse.success(signService.checkDuplicateEmail(email));
     }
 
+    @Operation(summary = "회원가입")
     @PostMapping("/sign-up")
     public ApiResponse signUp(@RequestBody SignUpRequest request) {
         return ApiResponse.success(signService.registerMember(request));
+    }
+
+    @Operation(summary = "로그인")
+    @PostMapping("/sign-in")
+    public ApiResponse signUp(@RequestBody SignInRequest request) {
+        return ApiResponse.success(signService.signIn(request));
     }
 }

--- a/src/main/java/com/challenger/fridge/domain/Member.java
+++ b/src/main/java/com/challenger/fridge/domain/Member.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.domain;
 
 import com.challenger.fridge.common.MemberType;
+import com.challenger.fridge.dto.sign.SignUpRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -9,11 +10,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
@@ -31,4 +37,14 @@ public class Member {
     private MemberType type;
 
     private LocalDateTime createdAt;
+
+    public static Member from(SignUpRequest request, PasswordEncoder encoder) {
+        return Member.builder()
+                .email(request.getEmail())
+                .password(encoder.encode(request.getPassword()))
+                .name(request.getName())
+                .type(MemberType.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/com/challenger/fridge/domain/Member.java
+++ b/src/main/java/com/challenger/fridge/domain/Member.java
@@ -1,6 +1,6 @@
 package com.challenger.fridge.domain;
 
-import com.challenger.fridge.common.MemberType;
+import com.challenger.fridge.common.MemberRole;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,7 +34,7 @@ public class Member {
     private String name;
 
     @Enumerated(EnumType.STRING)
-    private MemberType type;
+    private MemberRole role;
 
     private LocalDateTime createdAt;
 
@@ -43,7 +43,7 @@ public class Member {
                 .email(request.getEmail())
                 .password(encoder.encode(request.getPassword()))
                 .name(request.getName())
-                .type(MemberType.USER)
+                .role(MemberRole.ROLE_USER)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/main/java/com/challenger/fridge/dto/sign/SignInRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignInRequest.java
@@ -3,13 +3,14 @@ package com.challenger.fridge.dto.sign;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class SignUpRequest {
+public class SignInRequest {
 
     private String email;
     private String password;
-    private String name;
 }

--- a/src/main/java/com/challenger/fridge/dto/sign/SignInResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignInResponse.java
@@ -1,15 +1,18 @@
 package com.challenger.fridge.dto.sign;
 
+import com.challenger.fridge.common.MemberRole;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class SignUpRequest {
+public class SignInResponse {
 
-    private String email;
-    private String password;
     private String name;
+    private TokenInfo tokenInfo;
+
 }

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
@@ -1,0 +1,11 @@
+package com.challenger.fridge.dto.sign;
+
+import lombok.Getter;
+
+@Getter
+public class SignUpRequest {
+
+    private String email;
+    private String password;
+    private String name;
+}

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
@@ -1,8 +1,10 @@
 package com.challenger.fridge.dto.sign;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class SignUpRequest {
 
     private String email;

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpResponse.java
@@ -1,5 +1,8 @@
 package com.challenger.fridge.dto.sign;
 
+import lombok.Getter;
+
+@Getter
 public class SignUpResponse {
 
     String name;

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpResponse.java
@@ -1,0 +1,10 @@
+package com.challenger.fridge.dto.sign;
+
+public class SignUpResponse {
+
+    String name;
+
+    public SignUpResponse(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/com/challenger/fridge/dto/sign/TokenInfo.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/TokenInfo.java
@@ -1,0 +1,15 @@
+package com.challenger.fridge.dto.sign;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+@Builder
+@Data
+@AllArgsConstructor
+public class TokenInfo {
+
+    private String grantType;
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -1,0 +1,9 @@
+package com.challenger.fridge.handler;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionResponseHandler {
+
+
+}

--- a/src/main/java/com/challenger/fridge/repository/MemberRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.challenger.fridge.repository;
+
+import com.challenger.fridge.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    public boolean existsByEmail(String email);
+}

--- a/src/main/java/com/challenger/fridge/repository/MemberRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package com.challenger.fridge.repository;
 
 import com.challenger.fridge.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     public boolean existsByEmail(String email);
+    public Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/challenger/fridge/security/CustomUserDetails.java
+++ b/src/main/java/com/challenger/fridge/security/CustomUserDetails.java
@@ -1,0 +1,50 @@
+package com.challenger.fridge.security;
+
+import com.challenger.fridge.domain.Member;
+import java.util.Collection;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.member.getRole().name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/challenger/fridge/security/CustomUserDetailsService.java
+++ b/src/main/java/com/challenger/fridge/security/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.challenger.fridge.security;
+
+import com.challenger.fridge.domain.Member;
+import com.challenger.fridge.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username).orElseThrow
+                (() -> new UsernameNotFoundException("이메일과 비밀번호가 일치하지 않습니다."));
+        log.debug("loadUserByUsername user : {}", member);
+
+        return new CustomUserDetails(member);
+    }
+
+}

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -1,0 +1,11 @@
+package com.challenger.fridge.security;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+}

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -1,11 +1,41 @@
 package com.challenger.fridge.security;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter {
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = resolveToken((HttpServletRequest) request);
 
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/challenger/fridge/security/JwtTokenProvider.java
+++ b/src/main/java/com/challenger/fridge/security/JwtTokenProvider.java
@@ -1,19 +1,33 @@
 package com.challenger.fridge.security;
 
 import com.challenger.fridge.dto.sign.TokenInfo;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @PropertySource("classpath:application.yml")
 @Service
 public class JwtTokenProvider {
@@ -56,4 +70,58 @@ public class JwtTokenProvider {
                 .refreshToken(refreshToken)
                 .build();
     }
+
+    /**
+     * access token 을 복호화 하여 인증정보를 생성
+     */
+    public Authentication getAuthentication(String accessToken) {
+        // Jwt 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("auth") == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        // 클레임에서 권한 정보 가져오기
+        Collection<? extends GrantedAuthority> authorities = Arrays.stream(claims.get("auth").toString().split("."))
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+
+        // UserDetails 객체를 만들어서 Authentication 리턴
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty", e);
+        }
+        return false;
+    }
+
+
 }

--- a/src/main/java/com/challenger/fridge/security/JwtTokenProvider.java
+++ b/src/main/java/com/challenger/fridge/security/JwtTokenProvider.java
@@ -1,0 +1,59 @@
+package com.challenger.fridge.security;
+
+import com.challenger.fridge.dto.sign.TokenInfo;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.util.Date;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+
+@PropertySource("classpath:application.yml")
+@Service
+public class JwtTokenProvider {
+
+    private final Key key;
+
+    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    /**
+     * 유저 정보를 가지고 AccessToken, Refresh Token 생성
+     */
+    public TokenInfo generateToken(Authentication authentication) {
+        // 권한 가져오기
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+        long now = (new Date()).getTime();
+
+        // access Token 생성
+        Date accessTokenExpiresIn = new Date(now + 86400000);
+        String accessToken = Jwts.builder()
+                .setSubject(authentication.getName())
+                .claim("auth", authorities)
+                .setExpiration(accessTokenExpiresIn)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        // refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + 86400000))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return TokenInfo.builder()
+                .grantType("Bearer")
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/challenger/fridge/security/SecurityConfig.java
+++ b/src/main/java/com/challenger/fridge/security/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.challenger.fridge.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf((csrf) -> csrf.disable())
+                .authorizeHttpRequests(requests ->
+                        requests.requestMatchers("/", "/sign-in", "/sign-up", "/swagger-ui/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .sessionManagement(
+                        sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/challenger/fridge/security/SecurityConfig.java
+++ b/src/main/java/com/challenger/fridge/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.challenger.fridge.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,10 +10,14 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -20,13 +25,13 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.anyRequest().permitAll()
-//                        requests.requestMatchers("/", "/sign-in", "/sign-up", "/swagger-ui/**", "/v3/**").permitAll()
-//                                .anyRequest().authenticated()
+                        requests.requestMatchers("/", "/sign-in", "/sign-up", "/swagger-ui/**", "/v3/**").permitAll()
+                                .anyRequest().authenticated()
                 )
                 .sessionManagement(
                         sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
+                .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
                 .build();
     }
 

--- a/src/main/java/com/challenger/fridge/security/SecurityConfig.java
+++ b/src/main/java/com/challenger/fridge/security/SecurityConfig.java
@@ -3,21 +3,26 @@ package com.challenger.fridge.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
+@EnableWebSecurity
 public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
-                .csrf((csrf) -> csrf.disable())
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.requestMatchers("/", "/sign-in", "/sign-up", "/swagger-ui/**").permitAll()
-                                .anyRequest().authenticated()
+                        requests.anyRequest().permitAll()
+//                        requests.requestMatchers("/", "/sign-in", "/sign-up", "/swagger-ui/**", "/v3/**").permitAll()
+//                                .anyRequest().authenticated()
                 )
                 .sessionManagement(
                         sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -1,0 +1,36 @@
+package com.challenger.fridge.service;
+
+import com.challenger.fridge.domain.Member;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.dto.sign.SignUpResponse;
+import com.challenger.fridge.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class SignService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder encoder;
+
+    /**
+     * 회원 이메일 중복 확인 요청
+     */
+    public boolean checkDuplicateEmail(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+        }
+        return true;
+    }
+
+    @Transactional
+    public SignUpResponse registerMember(SignUpRequest request) {
+        Member member = memberRepository.save(Member.from(request, encoder));
+        return new SignUpResponse(member.getName());
+    }
+}

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -32,10 +32,11 @@ public class SignService {
      * 회원 이메일 중복 확인 요청
      */
     public boolean checkDuplicateEmail(String email) {
-        if (memberRepository.existsByEmail(email)) {
-            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
-        }
-        return true;
+//        if (memberRepository.existsByEmail(email)) {
+//            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+//        }
+//        return true;
+        return memberRepository.existsByEmail(email);
     }
 
     /**

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -1,10 +1,18 @@
 package com.challenger.fridge.service;
 
 import com.challenger.fridge.domain.Member;
+import com.challenger.fridge.dto.sign.SignInRequest;
+import com.challenger.fridge.dto.sign.SignInResponse;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.dto.sign.SignUpResponse;
 import com.challenger.fridge.repository.MemberRepository;
+import com.challenger.fridge.security.JwtTokenProvider;
+import com.challenger.fridge.dto.sign.TokenInfo;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +25,8 @@ public class SignService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder encoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
     /**
      * 회원 이메일 중복 확인 요청
@@ -36,4 +46,25 @@ public class SignService {
         Member member = memberRepository.save(Member.from(request, encoder));
         return new SignUpResponse(member.getName());
     }
+
+    /**
+     * 로그인
+     */
+    @Transactional
+    public SignInResponse signIn(SignInRequest request) {
+        // 1. email, password 기반 Authentication 객체 생성. -> 인증 여부를 확인하는 authenticated 값이 false
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                request.getEmail(), request.getPassword());
+
+        // 2. 검증 진행 - CustomUserDetailsService.loadUserByUsername 메서드가 실행
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+        // 3. member 에 refresh token 저장 - 미완
+        Member member = memberRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        TokenInfo tokenInfo = jwtTokenProvider.generateToken(authentication);
+        return new SignInResponse(member.getName(), tokenInfo);
+    }
+
 }

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -28,6 +28,9 @@ public class SignService {
         return true;
     }
 
+    /**
+     * 회원가입
+     */
     @Transactional
     public SignUpResponse registerMember(SignUpRequest request) {
         Member member = memberRepository.save(Member.from(request, encoder));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,12 @@ spring:
 logging:
   level:
     org.hibernate.SQL: debug
+
 springdoc:
   swagger-ui:
-    path: /fridge/swagger-ui.html
+    path: /swagger-ui.html
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
+
+jwt:
+  secret: 35c21b3de74471b7fd035869767f0cdb0b6adc041c74d252a4913df64ff3d3ec

--- a/src/test/java/com/challenger/fridge/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/challenger/fridge/repository/MemberRepositoryTest.java
@@ -1,0 +1,29 @@
+package com.challenger.fridge.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class MemberRepositoryTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("중복 사용자 확인")
+    void checkDuplicateEmail() {
+        String uniqueEmail = "jjw@test.com";
+        String duplicatedEmail = "cjw@test.com";
+        Assertions.assertThat(memberRepository.existsByEmail(uniqueEmail)).isTrue();
+        Assertions.assertThat(memberRepository.existsByEmail(duplicatedEmail)).isFalse();
+    }
+}

--- a/src/test/java/com/challenger/fridge/service/SignServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/SignServiceTest.java
@@ -1,0 +1,46 @@
+package com.challenger.fridge.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.challenger.fridge.repository.MemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SignServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private SignService signService;
+
+    @DisplayName("중복 이메일 입력시 예외 발생")
+    @Test
+    void createDuplicateEmailException() {
+        String email = "jjw1234@naver.com";
+        when(memberRepository.existsByEmail(anyString())).thenReturn(true);
+
+        assertThatThrownBy(() -> signService.checkDuplicateEmail(email))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("이미 사용중인 이메일입니다.");
+    }
+
+    @DisplayName("중복되지 않은 이메일 입력")
+    @Test
+    void createAdequateEmail() {
+        String email = "jjw1234@naver.com";
+        when(memberRepository.existsByEmail(anyString())).thenReturn(false);
+
+        assertThat(signService.checkDuplicateEmail(email)).isTrue();
+    }
+
+}

--- a/src/test/java/com/challenger/fridge/service/SignServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/SignServiceTest.java
@@ -1,18 +1,16 @@
 package com.challenger.fridge.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import com.challenger.fridge.common.MemberType;
+import com.challenger.fridge.common.MemberRole;
 import com.challenger.fridge.domain.Member;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.dto.sign.SignUpResponse;
 import com.challenger.fridge.repository.MemberRepository;
 import java.time.LocalDateTime;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +70,7 @@ class SignServiceTest {
                 .email("jjw@naver.com")
                 .password("1234")
                 .name("jjw")
-                .type(MemberType.USER)
+                .role(MemberRole.ROLE_USER)
                 .createdAt(LocalDateTime.now())
                 .build();
     }

--- a/src/test/java/com/challenger/fridge/service/SignServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/SignServiceTest.java
@@ -2,10 +2,16 @@ package com.challenger.fridge.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
+import com.challenger.fridge.common.MemberType;
+import com.challenger.fridge.domain.Member;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.dto.sign.SignUpResponse;
 import com.challenger.fridge.repository.MemberRepository;
+import java.time.LocalDateTime;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,12 +19,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class SignServiceTest {
 
     @Mock
     private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder encoder;
 
     @InjectMocks
     private SignService signService;
@@ -42,5 +52,30 @@ class SignServiceTest {
 
         assertThat(signService.checkDuplicateEmail(email)).isTrue();
     }
+
+    @DisplayName("회원가입")
+    @Test
+    void join() {
+        Long memberId = 1L;
+        Member testMember = createTestMember(memberId);
+        SignUpRequest request = new SignUpRequest("jjw@naver.com", "1234", "jjw");
+
+        SignUpResponse signUpResponse = new SignUpResponse("jjw");
+        when(memberRepository.save(any())).thenReturn(testMember);
+
+        assertThat(signService.registerMember(request).getName()).isEqualTo(signUpResponse.getName());
+    }
+
+    private Member createTestMember(Long memberId) {
+        return Member.builder()
+                .id(memberId)
+                .email("jjw@naver.com")
+                .password("1234")
+                .name("jjw")
+                .type(MemberType.USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
 
 }

--- a/src/test/java/com/challenger/fridge/service/SignServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/SignServiceTest.java
@@ -1,79 +1,48 @@
 package com.challenger.fridge.service;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
 
-import com.challenger.fridge.common.MemberRole;
-import com.challenger.fridge.domain.Member;
-import com.challenger.fridge.dto.sign.SignUpRequest;
-import com.challenger.fridge.dto.sign.SignUpResponse;
 import com.challenger.fridge.repository.MemberRepository;
-import java.time.LocalDateTime;
+import com.challenger.fridge.security.JwtTokenProvider;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@ExtendWith(MockitoExtension.class)
+@SpringBootTest
 class SignServiceTest {
 
-    @Mock
-    private MemberRepository memberRepository;
+    @Autowired SignService signService;
+    @Autowired MemberRepository memberRepository;
+    @Autowired PasswordEncoder encoder;
+    @Autowired JwtTokenProvider jwtTokenProvider;
+    @Autowired AuthenticationManagerBuilder authenticationManagerBuilder;
 
-    @Mock
-    private PasswordEncoder encoder;
+//    @DisplayName("사용중인 이메일 입력 시 예외 발생")
+//    @Test
+//    void createDuplicateEmailException() {
+//        String email = "jjw@test.com";
+//        assertThatThrownBy(() -> signService.checkDuplicateEmail(email))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("이미 사용중인 이메일입니다.");
+//    }
 
-    @InjectMocks
-    private SignService signService;
-
-    @DisplayName("중복 이메일 입력시 예외 발생")
+    @DisplayName("사용중이지 않은 이메일 입력")
     @Test
-    void createDuplicateEmailException() {
-        String email = "jjw1234@naver.com";
-        when(memberRepository.existsByEmail(anyString())).thenReturn(true);
-
-        assertThatThrownBy(() -> signService.checkDuplicateEmail(email))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage("이미 사용중인 이메일입니다.");
+    void failByDuplicateEmail() {
+        String email = "cjw@test.com";
+        assertThat(signService.checkDuplicateEmail(email)).isFalse();
     }
 
-    @DisplayName("중복되지 않은 이메일 입력")
+    @DisplayName("사용중인 이메일 입력")
     @Test
-    void createAdequateEmail() {
-        String email = "jjw1234@naver.com";
-        when(memberRepository.existsByEmail(anyString())).thenReturn(false);
-
+    void passNotDuplicateEmail() {
+        String email = "jjw@test.com";
         assertThat(signService.checkDuplicateEmail(email)).isTrue();
     }
-
-    @DisplayName("회원가입")
-    @Test
-    void join() {
-        Long memberId = 1L;
-        Member testMember = createTestMember(memberId);
-        SignUpRequest request = new SignUpRequest("jjw@naver.com", "1234", "jjw");
-
-        SignUpResponse signUpResponse = new SignUpResponse("jjw");
-        when(memberRepository.save(any())).thenReturn(testMember);
-
-        assertThat(signService.registerMember(request).getName()).isEqualTo(signUpResponse.getName());
-    }
-
-    private Member createTestMember(Long memberId) {
-        return Member.builder()
-                .id(memberId)
-                .email("jjw@naver.com")
-                .password("1234")
-                .name("jjw")
-                .role(MemberRole.ROLE_USER)
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
-
 
 }

--- a/src/test/java/com/challenger/fridge/service/SignServiceUnitTest.java
+++ b/src/test/java/com/challenger/fridge/service/SignServiceUnitTest.java
@@ -1,0 +1,79 @@
+package com.challenger.fridge.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.challenger.fridge.common.MemberRole;
+import com.challenger.fridge.domain.Member;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.dto.sign.SignUpResponse;
+import com.challenger.fridge.repository.MemberRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class SignServiceUnitTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PasswordEncoder encoder;
+
+    @InjectMocks
+    private SignService signService;
+
+    @DisplayName("중복 이메일 입력시 예외 발생")
+    @Test
+    void createDuplicateEmailException() {
+        String email = "jjw1234@naver.com";
+        when(memberRepository.existsByEmail(anyString())).thenReturn(true);
+
+//        assertThatThrownBy(() -> signService.checkDuplicateEmail(email))
+//                .isInstanceOf(IllegalArgumentException.class)
+//                .hasMessage("이미 사용중인 이메일입니다.");
+        assertThat(signService.checkDuplicateEmail(email)).isTrue();
+    }
+
+    @DisplayName("중복되지 않은 이메일 입력")
+    @Test
+    void createAdequateEmail() {
+        String email = "jjw1234@naver.com";
+        when(memberRepository.existsByEmail(anyString())).thenReturn(false);
+
+        assertThat(signService.checkDuplicateEmail(email)).isFalse();
+    }
+
+    @DisplayName("회원가입")
+    @Test
+    void join() {
+        Long memberId = 1L;
+        Member testMember = createTestMember(memberId);
+        SignUpRequest request = new SignUpRequest("jjw@naver.com", "1234", "jjw");
+
+        SignUpResponse signUpResponse = new SignUpResponse("jjw");
+        when(memberRepository.save(any())).thenReturn(testMember);
+
+        assertThat(signService.registerMember(request).getName()).isEqualTo(signUpResponse.getName());
+    }
+
+    private Member createTestMember(Long memberId) {
+        return Member.builder()
+                .id(memberId)
+                .email("jjw@naver.com")
+                .password("1234")
+                .name("jjw")
+                .role(MemberRole.ROLE_USER)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+}


### PR DESCRIPTION
### 회원가입 및 로그인 구현
회원가입시 이메일 중복 확인 기능, 회원가입 기능, 로그인 기능 총 세가지 구현

**이메일 중복 확인 기능**
- 이메일 중복 확인을 위한 단위테스트와 통합 테스트 작성.
- 하지만 포스트맨을 통해 api 호출은 늘 success로 돌아가는 문제 발견
- 
**로그인 기능**
- 스프링 시큐리티의 로그인 로직을 사용하여 CustomUserDetails와 CustomUserDetailsService 구현
- JwtAuthenticationFilter에서 OncePerRequestFilter를 요청 한번 당 한번의 인증만 하도록 구현
- 로그인시 리프레시 토큰을 entity에 저장하는 로직과 로그인 테스트를 다음 스텝에서 할 예정