### PR TITLE
Feature join unit test

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -7,14 +7,17 @@ import com.challenger.fridge.service.SignService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "회원가입 및 로그인")
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping
@@ -24,11 +27,12 @@ public class SignController {
 
     @Operation(summary = "회원 이메일 중복 체크")
     @GetMapping("/sign-up")
-    public ApiResponse checkEmail(@RequestBody String email) {
+    public ApiResponse checkEmail(@RequestParam String email) {
+        log.info("Controller : email={}", email);
 //        return ApiResponse.success(signService.checkDuplicateEmail(email));
         boolean result = signService.checkDuplicateEmail(email);
         if (result) {
-            return ApiResponse.error("사용중인 이메일입니다. 다시 입력해주세요");
+            return ApiResponse.error("이미 사용중인 이메일입니다");
         } else {
             return ApiResponse.success(null);
         }

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -29,13 +29,15 @@ public class SignController {
     @GetMapping("/sign-up")
     public ApiResponse checkEmail(@RequestParam String email) {
         log.info("Controller : email={}", email);
+        signService.checkDuplicateEmail(email);
+        return ApiResponse.success(null);
 //        return ApiResponse.success(signService.checkDuplicateEmail(email));
-        boolean result = signService.checkDuplicateEmail(email);
-        if (result) {
-            return ApiResponse.error("이미 사용중인 이메일입니다");
-        } else {
-            return ApiResponse.success(null);
-        }
+//        boolean result = signService.checkDuplicateEmail(email);
+//        if (result) {
+//            return ApiResponse.error("이미 사용중인 이메일입니다");
+//        } else {
+//            return ApiResponse.success(null);
+//        }
     }
 
     @Operation(summary = "회원가입")

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -1,9 +1,15 @@
 package com.challenger.fridge.handler;
 
+import com.challenger.fridge.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class ExceptionResponseHandler {
 
-
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiResponse> handleIllegalArgumentException(Exception e) {
+        return ResponseEntity.badRequest().body(ApiResponse.error(e.getMessage()));
+    }
 }

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -9,6 +9,7 @@ import com.challenger.fridge.repository.MemberRepository;
 import com.challenger.fridge.security.JwtTokenProvider;
 import com.challenger.fridge.dto.sign.TokenInfo;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
@@ -17,7 +18,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -32,6 +33,7 @@ public class SignService {
      * 회원 이메일 중복 확인 요청
      */
     public boolean checkDuplicateEmail(String email) {
+        log.info("Service : email={}", email);
 //        if (memberRepository.existsByEmail(email)) {
 //            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
 //        }

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -34,11 +34,11 @@ public class SignService {
      */
     public boolean checkDuplicateEmail(String email) {
         log.info("Service : email={}", email);
-//        if (memberRepository.existsByEmail(email)) {
-//            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
-//        }
-//        return true;
-        return memberRepository.existsByEmail(email);
+        if (memberRepository.existsByEmail(email)) {
+            throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
+        }
+        return true;
+//        return memberRepository.existsByEmail(email);
     }
 
     /**

--- a/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
+++ b/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
@@ -1,0 +1,118 @@
+package com.challenger.fridge.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.dto.sign.SignUpResponse;
+import com.challenger.fridge.repository.MemberRepository;
+import com.challenger.fridge.service.SignService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SignController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+class SignControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper; // response 를 json 으로 바꿔주기 위해 필요한 의존성 주입
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SignService signService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("POST 회원 등록 컨트롤러 로직 확인")
+    void signUpTest() throws Exception {
+        String name = "jjw";
+        SignUpRequest request = createSignUpRequest(name);
+        SignUpResponse response = createSignUpResponse(name);
+        ApiResponse apiResponse = createApiSuccessResponse(response);
+
+        given(signService.registerMember(any(SignUpRequest.class))).willReturn(response);
+
+        String requestJson = objectMapper.writeValueAsString(request);
+        String responseJson = objectMapper.writeValueAsString(apiResponse);
+
+        mockMvc.perform(post("/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("GET 이메일 중복 확인 컨틀로러 로직 확인 - 중복 X")
+    void checkUniqueEmail() throws Exception {
+        String requestEmail = "jjw@test.com";
+        boolean response = false;
+        ApiResponse apiResponse = createApiSuccessResponse(null);
+
+        given(signService.checkDuplicateEmail(anyString())).willReturn(response);
+
+        String responseJson = objectMapper.writeValueAsString(apiResponse);
+
+        mockMvc.perform(get("/sign-up")
+                        .param("email", requestEmail))
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    @DisplayName("GET 이메일 중복 확인 컨틀로러 로직 확인 - 중복 O")
+    void checkDuplicateEmail() throws Exception {
+        String requestEmail = "jjw@test.com";
+        String errorMessage = "이미 사용중인 이메일입니다";
+
+        boolean response = true;
+        ApiResponse apiResponse = createApiErrorResponse(errorMessage);
+
+        given(signService.checkDuplicateEmail(anyString())).willReturn(response);
+
+        String responseJson = objectMapper.writeValueAsString(apiResponse);
+
+        mockMvc.perform(get("/sign-up")
+                        .param("email", requestEmail))
+                .andExpect(status().isOk())
+                .andExpect(content().json(responseJson))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    private ApiResponse createApiErrorResponse(String message) {
+        ApiResponse apiResponse = ApiResponse.error(message);
+        return apiResponse;
+    }
+
+    private ApiResponse createApiSuccessResponse(SignUpResponse response) {
+        return ApiResponse.success(response);
+    }
+
+    private SignUpResponse createSignUpResponse(String name) {
+        return new SignUpResponse(name);
+    }
+
+    private SignUpRequest createSignUpRequest(String name) {
+        return new SignUpRequest("jjw@test.com", "1234", name);
+    }
+}

--- a/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
+++ b/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
@@ -14,6 +14,7 @@ import com.challenger.fridge.dto.sign.SignUpResponse;
 import com.challenger.fridge.repository.MemberRepository;
 import com.challenger.fridge.service.SignService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +66,7 @@ class SignControllerTest {
     @DisplayName("GET 이메일 중복 확인 컨틀로러 로직 확인 - 중복 X")
     void checkUniqueEmail() throws Exception {
         String requestEmail = "jjw@test.com";
-        boolean response = false;
+        boolean response = true;
         ApiResponse apiResponse = createApiSuccessResponse(null);
 
         given(signService.checkDuplicateEmail(anyString())).willReturn(response);
@@ -85,16 +86,15 @@ class SignControllerTest {
         String requestEmail = "jjw@test.com";
         String errorMessage = "이미 사용중인 이메일입니다";
 
-        boolean response = true;
         ApiResponse apiResponse = createApiErrorResponse(errorMessage);
 
-        given(signService.checkDuplicateEmail(anyString())).willReturn(response);
+        given(signService.checkDuplicateEmail(anyString())).willThrow(new IllegalArgumentException(errorMessage));
 
         String responseJson = objectMapper.writeValueAsString(apiResponse);
 
         mockMvc.perform(get("/sign-up")
                         .param("email", requestEmail))
-                .andExpect(status().isOk())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().json(responseJson))
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }


### PR DESCRIPTION
**회원가입 테스트**
- 기존 이메일 중복 확인 api는 모두 SignController에서 Http 상태코드 200으로 반환하였다. SignService#checkDuplicateEmail() 에서 중복된 이메일인 경우 예외를 던져 ExceptionResponseHandler에서 예외 response를 생성하면서 예외를 처리하도록 변경
- SignService와 SignController의 단위 테스트 작성을 위해 의존성을 끊는 Mockito 라이브러리를 사용