### PR TITLE
조회 API 완성

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
@@ -1,12 +1,14 @@
 package com.challenger.fridge.controller;
 
 import com.challenger.fridge.dto.ApiResponse;
-import com.challenger.fridge.dto.item.StorageItemDto;
+import com.challenger.fridge.dto.item.request.StorageItemRequest;
 import com.challenger.fridge.service.StorageBoxService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,10 +19,13 @@ public class StorageBoxController {
 
     @PostMapping("/{storageBoxId}/items/new")
     @Operation(summary = "(검색 탭에서)세부 보관소에 상품 추가", description = "세부 보관소에 상품을 추가한다.(검색 탭에서 냉장고로 바로 추가)")
-    public ApiResponse addStorageItemToStorageBox(@RequestBody StorageItemDto storageItemDto, @PathVariable("storageBoxId") Long storageBoxId) {
-        storageBoxService.saveStorageItem(storageItemDto, storageBoxId);
+    public ApiResponse addStorageItemToStorageBox(@RequestBody StorageItemRequest storageItemRequest, @PathVariable("storageBoxId") Long storageBoxId) {
+        storageBoxService.saveStorageItem(storageItemRequest, storageBoxId);
         return ApiResponse.success(null);
     }
+
+
+
 
 
 }

--- a/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.controller;
 
 import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.box.response.StorageBoxResponse;
 import com.challenger.fridge.dto.item.request.StorageItemRequest;
 import com.challenger.fridge.service.StorageBoxService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,8 +25,14 @@ public class StorageBoxController {
         return ApiResponse.success(null);
     }
 
+    @GetMapping("/{storageBoxId}")
+    @Operation(summary = "세부 보관소 상품 카테고리별 단건 조회(필터)", description = "세부 보관소 정보와 상품들을 카테고리 별로 조회(url에 파라미터를 보내면 필터 기능) 파라미터가 없다면 그냥 단건 조회")
+    public ApiResponse getStorageBox(@PathVariable Long storageBoxId,
+                                     @RequestParam(name = "categoryName",required = false) List<String> categoryNames) {
+        StorageBoxResponse storageBoxResponse = storageBoxService.findStorageBox(categoryNames, storageBoxId);
+        return ApiResponse.success(storageBoxResponse);
 
-
+    }
 
 
 }

--- a/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageBoxController.java
@@ -1,8 +1,12 @@
 package com.challenger.fridge.controller;
 
+import com.challenger.fridge.domain.StorageItem;
 import com.challenger.fridge.dto.ApiResponse;
 import com.challenger.fridge.dto.box.response.StorageBoxResponse;
 import com.challenger.fridge.dto.item.request.StorageItemRequest;
+import com.challenger.fridge.dto.item.response.StorageItemResponse;
+import com.challenger.fridge.exception.StorageItemNotFoundException;
+import com.challenger.fridge.repository.StorageItemRepository;
 import com.challenger.fridge.service.StorageBoxService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -17,6 +21,7 @@ import java.util.List;
 @Tag(name = "storagebox", description = "세부보관소 API")
 public class StorageBoxController {
     private final StorageBoxService storageBoxService;
+    private final StorageItemRepository storageItemRepository;
 
     @PostMapping("/{storageBoxId}/items/new")
     @Operation(summary = "(검색 탭에서)세부 보관소에 상품 추가", description = "세부 보관소에 상품을 추가한다.(검색 탭에서 냉장고로 바로 추가)")
@@ -28,10 +33,21 @@ public class StorageBoxController {
     @GetMapping("/{storageBoxId}")
     @Operation(summary = "세부 보관소 상품 카테고리별 단건 조회(필터)", description = "세부 보관소 정보와 상품들을 카테고리 별로 조회(url에 파라미터를 보내면 필터 기능) 파라미터가 없다면 그냥 단건 조회")
     public ApiResponse getStorageBox(@PathVariable Long storageBoxId,
-                                     @RequestParam(name = "categoryName",required = false) List<String> categoryNames) {
+                                     @RequestParam(name = "categoryName", required = false) List<String> categoryNames) {
         StorageBoxResponse storageBoxResponse = storageBoxService.findStorageBox(categoryNames, storageBoxId);
         return ApiResponse.success(storageBoxResponse);
 
+    }
+
+    @GetMapping("/items/{storageItemId}")
+    @Operation(summary = "세부 보관소에 있는 상품 단건 조회", description = "세부 보관소에 있는 상품을 단건으로 조회한다. (상품 상세 정보)")
+    public ApiResponse getStorageBox(@PathVariable Long storageItemId) {
+        //단건 조회 로직인데 구지 StorageBoxRepository에서 찾지 않았다 storageBox에서 찾을 수 있지만 Repository에서 메소드를 작성해야 한다
+        //결국에는 단건 조회이기 때문에 양방향에서 찾는다해서 큰 장점을 느낄 수 가 없는거 같다.
+        //또한 세부 보관소에서 storageItemId을 찾는건 결국 storageItemId만 필요하다.
+        //구지 (컨트롤러 -> 서비스 로직 -> 레포지토리)가 아니라 (컨트롤러 -> 레포지토리 방향으로 가는 것이 나은 것 같다)
+        StorageItem storageItem = storageItemRepository.findById(storageItemId).orElseThrow(() -> new StorageItemNotFoundException("해당하는 상품이 세부 보관소에 없습니다."));
+        return ApiResponse.success(new StorageItemResponse(storageItem));
     }
 
 

--- a/src/main/java/com/challenger/fridge/controller/StorageController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageController.java
@@ -3,6 +3,7 @@ package com.challenger.fridge.controller;
 import com.challenger.fridge.dto.ApiResponse;
 import com.challenger.fridge.dto.box.request.StorageBoxSaveRequest;
 import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
+import com.challenger.fridge.dto.storage.response.StorageResponse;
 import com.challenger.fridge.service.StorageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -29,6 +32,14 @@ public class StorageController {
         return ApiResponse.success(null);
     }
 
+    @GetMapping
+    @Operation(summary = "보관소 전체 조회", description = "보관소들의 정보들을 전체 조회한다.")
+    public ApiResponse getStorage(@AuthenticationPrincipal User user) {
+        String userEmail = user.getUsername();
+        List<StorageResponse> storageList = storageService.findStorage(userEmail);
+        return ApiResponse.success(storageList);
+    }
+
     @PostMapping("/{storageId}/storagebox/new")
     @Operation(summary = "세부 보관소 추가", description = "세부 보관소를 추가한다(사용자가 FRIDGE,FREEZE 둘 중 하나를 선택해서 추가 할 수 있다.")
     public ApiResponse createStorageBox(@Valid @RequestBody StorageBoxSaveRequest storageBoxSaveRequest
@@ -36,6 +47,9 @@ public class StorageController {
         storageService.saveStorageBox(storageBoxSaveRequest, storageId);
         return ApiResponse.success(null);
     }
+
+
+
 
 
 }

--- a/src/main/java/com/challenger/fridge/domain/StorageItem.java
+++ b/src/main/java/com/challenger/fridge/domain/StorageItem.java
@@ -3,7 +3,7 @@ package com.challenger.fridge.domain;
 import static jakarta.persistence.FetchType.*;
 
 import com.challenger.fridge.domain.box.StorageBox;
-import com.challenger.fridge.dto.item.StorageItemDto;
+import com.challenger.fridge.dto.item.request.StorageItemRequest;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -60,13 +60,13 @@ public class StorageItem {
         this.purchaseDate = purchaseDate;
     }
 
-    public static StorageItem createStorageItem(StorageItemDto storageItemDto,Item item,StorageBox storageBox)
+    public static StorageItem createStorageItem(StorageItemRequest storageItemRequest, Item item, StorageBox storageBox)
     {
-        System.out.println(storageItemDto.getPurchaseDateAsLocalDate());
-        StorageItem storageItem=new StorageItem(storageItemDto.getItemCount()
-                                            ,storageItemDto.getItemDescription()
-                                            ,storageItemDto.getExpireDateAsLocalDate()
-                                            ,storageItemDto.getPurchaseDateAsLocalDate());
+        System.out.println(storageItemRequest.getPurchaseDateAsLocalDate());
+        StorageItem storageItem=new StorageItem(storageItemRequest.getItemCount()
+                                            ,storageItemRequest.getItemDescription()
+                                            ,storageItemRequest.getExpireDateAsLocalDate()
+                                            ,storageItemRequest.getPurchaseDateAsLocalDate());
         storageItem.addItem(item);
         storageItem.addStorageBox(storageBox);
         return storageItem;

--- a/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
@@ -1,0 +1,20 @@
+package com.challenger.fridge.dto.box.response;
+
+import com.challenger.fridge.domain.box.StorageBox;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "세부 보관소 정보 Response")
+public class StorageBoxResponse {
+    @Schema(description = "세부 보관소 고유 ID")
+    private Long storageBoxId;
+    @Schema(description = "세부 보관소 이름")
+    private String storageBoxName;
+
+    public StorageBoxResponse(StorageBox storageBox) {
+        this.storageBoxId = storageBox.getId();
+        this.storageBoxName = storageBox.getName();
+
+    }
+}

--- a/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
@@ -1,8 +1,12 @@
 package com.challenger.fridge.dto.box.response;
 
 import com.challenger.fridge.domain.box.StorageBox;
+import com.challenger.fridge.dto.item.response.CategoryStorageItemResponse;
+import com.challenger.fridge.dto.storage.response.StorageResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+
+import java.util.List;
 
 @Data
 @Schema(description = "세부 보관소 정보 Response")
@@ -11,10 +15,17 @@ public class StorageBoxResponse {
     private Long storageBoxId;
     @Schema(description = "세부 보관소 이름")
     private String storageBoxName;
+    @Schema(description = "세부 보관소 내에 있는 카테고리별 상품 리스트")
+    private List<CategoryStorageItemResponse> categoriesItems;
 
     public StorageBoxResponse(StorageBox storageBox) {
         this.storageBoxId = storageBox.getId();
         this.storageBoxName = storageBox.getName();
+    }
+    public StorageBoxResponse(StorageBox storageBox,List<CategoryStorageItemResponse> categoryStorageItemList) {
+        this.storageBoxId = storageBox.getId();
+        this.storageBoxName = storageBox.getName();
+        this.categoriesItems=categoryStorageItemList;
 
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/box/response/StorageBoxResponse.java
@@ -3,13 +3,16 @@ package com.challenger.fridge.dto.box.response;
 import com.challenger.fridge.domain.box.StorageBox;
 import com.challenger.fridge.dto.item.response.CategoryStorageItemResponse;
 import com.challenger.fridge.dto.storage.response.StorageResponse;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Data
 @Schema(description = "세부 보관소 정보 Response")
+@JsonInclude(JsonInclude.Include.NON_NULL) //null인 데이터는 포함하지 않음
 public class StorageBoxResponse {
     @Schema(description = "세부 보관소 고유 ID")
     private Long storageBoxId;
@@ -18,14 +21,22 @@ public class StorageBoxResponse {
     @Schema(description = "세부 보관소 내에 있는 카테고리별 상품 리스트")
     private List<CategoryStorageItemResponse> categoriesItems;
 
-    public StorageBoxResponse(StorageBox storageBox) {
-        this.storageBoxId = storageBox.getId();
-        this.storageBoxName = storageBox.getName();
+    public static StorageBoxResponse createStorageBoxResponse(StorageBox storageBox)
+    {
+       StorageBoxResponse storageBoxResponse=new StorageBoxResponse();
+       storageBoxResponse.setStorageBoxId(storageBox.getId());
+       storageBoxResponse.setStorageBoxName(storageBox.getName());
+       return storageBoxResponse;
     }
-    public StorageBoxResponse(StorageBox storageBox,List<CategoryStorageItemResponse> categoryStorageItemList) {
-        this.storageBoxId = storageBox.getId();
-        this.storageBoxName = storageBox.getName();
-        this.categoriesItems=categoryStorageItemList;
 
+    public static StorageBoxResponse createStorageBoxDetailResponse(StorageBox storageBox,List<CategoryStorageItemResponse> categoriesItems)
+    {
+        StorageBoxResponse storageBoxResponse=new StorageBoxResponse();
+        storageBoxResponse.setStorageBoxId(storageBox.getId());
+        storageBoxResponse.setStorageBoxName(storageBox.getName());
+        storageBoxResponse.setCategoriesItems(categoriesItems);
+        return storageBoxResponse;
     }
+
+
 }

--- a/src/main/java/com/challenger/fridge/dto/item/request/StorageItemRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/item/request/StorageItemRequest.java
@@ -1,4 +1,4 @@
-package com.challenger.fridge.dto.item;
+package com.challenger.fridge.dto.item.request;
 
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter;
 
 @Data
 @Schema(description = "보관 아이템을 나타내는 DTO")
-public class StorageItemDto {
+public class StorageItemRequest {
     @Schema(description = "아이템의 고유 식별자")
     private Long itemId;
 

--- a/src/main/java/com/challenger/fridge/dto/item/response/CategoryStorageItemResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/item/response/CategoryStorageItemResponse.java
@@ -1,0 +1,19 @@
+package com.challenger.fridge.dto.item.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+@Data
+@Schema(description = "카테고리별 상품 리스트")
+public class CategoryStorageItemResponse {
+    @Schema(description = "카테고리 이름")
+    private String categoryName;
+    @Schema(description = "세부 보관소 상품 리스트")
+    private List<StorageItemResponse> storageItems;
+
+    public CategoryStorageItemResponse(String categoryName, List<StorageItemResponse> storageItems) {
+        this.categoryName = categoryName;
+        this.storageItems = storageItems;
+    }
+}

--- a/src/main/java/com/challenger/fridge/dto/item/response/StorageItemResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/item/response/StorageItemResponse.java
@@ -35,5 +35,4 @@ public class StorageItemResponse {
 
 
 
-
 }

--- a/src/main/java/com/challenger/fridge/dto/item/response/StorageItemResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/item/response/StorageItemResponse.java
@@ -1,0 +1,39 @@
+package com.challenger.fridge.dto.item.response;
+
+import com.challenger.fridge.domain.StorageItem;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+@Data
+@Schema(description = "세부 보관소 StorageItem 정보")
+public class StorageItemResponse {
+    @Schema(description = "세부 보관소 상품 고유 ID")
+    private Long storageItemId;
+    @Schema(description = "상품 고유 ID")
+    private Long itemId;
+    @Schema(description = "상품 이름")
+    private String itemName;
+    @Schema(description = "상품 개수")
+    private Long itemCount;
+    @Schema(description = "상품 설명")
+    private String itemDescription;
+    @Schema(description = "유통 기한")
+    private LocalDate expirationDate;
+
+    public StorageItemResponse(StorageItem storageItem) {
+        this.storageItemId = storageItem.getId();
+        this.itemId = storageItem.getItem().getId();
+        this.itemName = storageItem.getItem().getItemName();
+        this.itemCount = storageItem.getQuantity();
+        this.itemDescription = storageItem.getItemDescription();
+        this.expirationDate=storageItem.getExpirationDate();
+    }
+
+
+
+
+}

--- a/src/main/java/com/challenger/fridge/dto/storage/response/StorageResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/storage/response/StorageResponse.java
@@ -26,7 +26,7 @@ public class StorageResponse {
         this.storageStatus = storage.getStatus();
         this.storageName = storage.getName();
         this.storageBoxes = storage.getStorageBoxList().stream()
-                .map(storageBox -> new StorageBoxResponse(storageBox))
+                .map(storageBox -> StorageBoxResponse.createStorageBoxResponse(storageBox))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/challenger/fridge/dto/storage/response/StorageResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/storage/response/StorageResponse.java
@@ -1,0 +1,33 @@
+package com.challenger.fridge.dto.storage.response;
+
+import com.challenger.fridge.common.StorageStatus;
+import com.challenger.fridge.domain.Storage;
+import com.challenger.fridge.dto.box.response.StorageBoxResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@Schema(description = "보관소 정보 Response")
+public class StorageResponse {
+    @Schema(description = "보관소 고유 ID")
+    private Long storageId;
+    @Schema(description = "보관소 고유 타입")
+    private StorageStatus storageStatus;
+    @Schema(description = "보관소 이름")
+    private String storageName;
+    @Schema(description = "보관소 내 세부 보관소 정보 리스트")
+    private List<StorageBoxResponse> storageBoxes;
+
+    public StorageResponse(Storage storage) {
+        this.storageId = storage.getId();
+        this.storageStatus = storage.getStatus();
+        this.storageName = storage.getName();
+        this.storageBoxes = storage.getStorageBoxList().stream()
+                .map(storageBox -> new StorageBoxResponse(storageBox))
+                .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -36,10 +36,10 @@ public class ExceptionResponseHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("토큰이 만료되었습니다. 다시 로그인해주세요."));
     }
 
-    @ExceptionHandler(Exception.class)
+   /* @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleException() {
         return ResponseEntity.internalServerError().body(ApiResponse.error("서버에 문제가 발생했습니다."));
-    }
+    }*/
 
     @ExceptionHandler(StorageItemNotFoundException.class)
     public ResponseEntity<ApiResponse> handleStorageItemNotFoundException(StorageItemNotFoundException e) {

--- a/src/main/java/com/challenger/fridge/repository/MemberRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/MemberRepository.java
@@ -2,11 +2,12 @@ package com.challenger.fridge.repository;
 
 import com.challenger.fridge.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
     public boolean existsByEmail(String email);
+
     public Optional<Member> findByEmail(String email);
 
 }

--- a/src/main/java/com/challenger/fridge/repository/StorageBoxRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/StorageBoxRepository.java
@@ -2,8 +2,26 @@ package com.challenger.fridge.repository;
 
 import com.challenger.fridge.domain.box.StorageBox;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 
 public interface StorageBoxRepository extends JpaRepository<StorageBox, Long> {
+    @Query("select distinct sb from StorageBox sb " +
+            "join fetch sb.storageItemList sl " +
+            "join fetch sl.item i " +
+            "join fetch i.category c " +
+            "where sb.id=:storageBoxId " +
+            "and c.categoryName in :categories")
+    Optional<StorageBox> findStorageItemsByIdAndCategories(@Param("storageBoxId") Long storageBoxId, @Param("categories") List<String> categories);
 
+    @Query("select distinct sb from StorageBox sb " +
+            "join fetch sb.storageItemList sl " +
+            "join fetch sl.item i " +
+            "join fetch i.category c " +
+            "where sb.id=:storageBoxId ")
+    Optional<StorageBox> findStorageItemsById(@Param("storageBoxId") Long storageBoxId);
 }

--- a/src/main/java/com/challenger/fridge/repository/StorageRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/StorageRepository.java
@@ -1,8 +1,16 @@
 package com.challenger.fridge.repository;
 
+import com.challenger.fridge.domain.Member;
 import com.challenger.fridge.domain.Storage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface StorageRepository extends JpaRepository<Storage, Long> {
+    @Query("select s from Storage s join fetch s.storageBoxList where s.member=:member")
+    List<Storage> findStorageListByMember(@Param("member") Member member);
 
 }

--- a/src/main/java/com/challenger/fridge/service/StorageBoxService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageBoxService.java
@@ -3,7 +3,10 @@ package com.challenger.fridge.service;
 import com.challenger.fridge.domain.Item;
 import com.challenger.fridge.domain.StorageItem;
 import com.challenger.fridge.domain.box.StorageBox;
+import com.challenger.fridge.dto.box.response.StorageBoxResponse;
 import com.challenger.fridge.dto.item.request.StorageItemRequest;
+import com.challenger.fridge.dto.item.response.CategoryStorageItemResponse;
+import com.challenger.fridge.dto.item.response.StorageItemResponse;
 import com.challenger.fridge.exception.ItemNotFoundException;
 import com.challenger.fridge.exception.StorageBoxNotFoundException;
 import com.challenger.fridge.repository.ItemRepository;
@@ -11,20 +14,52 @@ import com.challenger.fridge.repository.StorageBoxRepository;
 import com.challenger.fridge.repository.StorageItemRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class StorageBoxService {
     private final StorageBoxRepository storageBoxRepository;
     private final ItemRepository itemRepository;
     private final StorageItemRepository storageItemRepository;
 
+    @Transactional
     public Long saveStorageItem(StorageItemRequest storageItemRequest, Long storageBoxId) {
         StorageBox storageBox = storageBoxRepository.findById(storageBoxId).orElseThrow(() -> new StorageBoxNotFoundException("해당 세부 보관소가 없습니다."));
         Item item = itemRepository.findById(storageItemRequest.getItemId()).orElseThrow(() -> new ItemNotFoundException("해당 하는 상품이 없습니다."));
         StorageItem storageItem = StorageItem.createStorageItem(storageItemRequest, item, storageBox);
         StorageItem savedStorageItem = storageItemRepository.save(storageItem);
         return savedStorageItem.getId();
+    }
+
+
+    public StorageBoxResponse findStorageBox(List<String> categoriesName, Long storageBoxId) {
+        StorageBox storageBox;
+
+        if (categoriesName != null) {
+            storageBox = storageBoxRepository.findStorageItemsByIdAndCategories(storageBoxId, categoriesName)
+                    .orElseThrow(() -> new StorageBoxNotFoundException("해당 세부 보관소가 없습니다."));
+        } else {
+            storageBox = storageBoxRepository.findStorageItemsById(storageBoxId)
+                    .orElseThrow(() -> new StorageBoxNotFoundException("해당 세부 보관소가 없습니다."));
+        }
+
+        Map<String, List<StorageItemResponse>> categoryStorageItemMap = storageBox.getStorageItemList().stream()
+                .collect(Collectors.groupingBy(
+                        storageItem -> storageItem.getItem().getCategory().getCategoryName(),
+                        Collectors.mapping(storageItem -> new StorageItemResponse(storageItem), Collectors.toList())
+                ));
+        List<CategoryStorageItemResponse> categoryStorageItemList = categoryStorageItemMap.entrySet().stream()
+                .map(storageItem -> new CategoryStorageItemResponse(storageItem.getKey(), storageItem.getValue()))
+                .collect(Collectors.toList());
+        StorageBoxResponse storageBoxResponse = new StorageBoxResponse(storageBox, categoryStorageItemList);
+        return storageBoxResponse;
     }
 
 

--- a/src/main/java/com/challenger/fridge/service/StorageBoxService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageBoxService.java
@@ -3,7 +3,7 @@ package com.challenger.fridge.service;
 import com.challenger.fridge.domain.Item;
 import com.challenger.fridge.domain.StorageItem;
 import com.challenger.fridge.domain.box.StorageBox;
-import com.challenger.fridge.dto.item.StorageItemDto;
+import com.challenger.fridge.dto.item.request.StorageItemRequest;
 import com.challenger.fridge.exception.ItemNotFoundException;
 import com.challenger.fridge.exception.StorageBoxNotFoundException;
 import com.challenger.fridge.repository.ItemRepository;
@@ -19,12 +19,13 @@ public class StorageBoxService {
     private final ItemRepository itemRepository;
     private final StorageItemRepository storageItemRepository;
 
-    public Long saveStorageItem(StorageItemDto storageItemDto, Long storageBoxId) {
+    public Long saveStorageItem(StorageItemRequest storageItemRequest, Long storageBoxId) {
         StorageBox storageBox = storageBoxRepository.findById(storageBoxId).orElseThrow(() -> new StorageBoxNotFoundException("해당 세부 보관소가 없습니다."));
-        Item item = itemRepository.findById(storageItemDto.getItemId()).orElseThrow(() -> new ItemNotFoundException("해당 하는 상품이 없습니다."));
-        StorageItem storageItem = StorageItem.createStorageItem(storageItemDto, item, storageBox);
+        Item item = itemRepository.findById(storageItemRequest.getItemId()).orElseThrow(() -> new ItemNotFoundException("해당 하는 상품이 없습니다."));
+        StorageItem storageItem = StorageItem.createStorageItem(storageItemRequest, item, storageBox);
         StorageItem savedStorageItem = storageItemRepository.save(storageItem);
         return savedStorageItem.getId();
     }
+
 
 }

--- a/src/main/java/com/challenger/fridge/service/StorageBoxService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageBoxService.java
@@ -57,7 +57,7 @@ public class StorageBoxService {
         List<CategoryStorageItemResponse> categoryStorageItemList = categoryStorageItemMap.entrySet().stream()
                 .map(storageItem -> new CategoryStorageItemResponse(storageItem.getKey(), storageItem.getValue()))
                 .collect(Collectors.toList());
-        StorageBoxResponse storageBoxResponse = new StorageBoxResponse(storageBox, categoryStorageItemList);
+        StorageBoxResponse storageBoxResponse = StorageBoxResponse.createStorageBoxDetailResponse(storageBox, categoryStorageItemList);
         return storageBoxResponse;
     }
 

--- a/src/main/java/com/challenger/fridge/service/StorageBoxService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageBoxService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/com/challenger/fridge/service/StorageService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageService.java
@@ -7,6 +7,7 @@ import com.challenger.fridge.domain.box.StorageBox;
 import com.challenger.fridge.dto.box.request.StorageBoxSaveRequest;
 import com.challenger.fridge.dto.box.request.StorageMethod;
 import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
+import com.challenger.fridge.dto.storage.response.StorageResponse;
 import com.challenger.fridge.exception.StorageBoxNameDuplicateException;
 import com.challenger.fridge.exception.StorageNameDuplicateException;
 import com.challenger.fridge.exception.StorageNotFoundException;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -58,6 +60,17 @@ public class StorageService {
         StorageBox savedstorageBox = storageBoxRepository.save(storageBox);
         return savedstorageBox.getId();
     }
+
+    public List<StorageResponse> findStorage(String userEmail)
+    {
+        Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new UserEmailNotFoundException("해당하는 회원이 없습니다."));
+        // 이부분은 쿼리가 많이 나가는 단점이 있다 //추후 수정 예정 member에 찾을 수 있는 장점은 있지만 lazy라 N+1 문제 발생
+        return member.getStorageList().stream().map(storage -> new StorageResponse(storage))
+                .collect(Collectors.toList());
+    }
+
+
+
 
 
 }

--- a/src/main/java/com/challenger/fridge/service/StorageService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageService.java
@@ -61,16 +61,13 @@ public class StorageService {
         return savedstorageBox.getId();
     }
 
-    public List<StorageResponse> findStorage(String userEmail)
-    {
+    public List<StorageResponse> findStorage(String userEmail) {
         Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new UserEmailNotFoundException("해당하는 회원이 없습니다."));
-        // 이부분은 쿼리가 많이 나가는 단점이 있다 //추후 수정 예정 member에 찾을 수 있는 장점은 있지만 lazy라 N+1 문제 발생
-        return member.getStorageList().stream().map(storage -> new StorageResponse(storage))
+        List<Storage> storageListByMember = storageRepository.findStorageListByMember(member);
+        return storageListByMember.stream().map(storage -> new StorageResponse(storage))
                 .collect(Collectors.toList());
+
     }
-
-
-
 
 
 }


### PR DESCRIPTION
1.보관소 전체 조회 API 완성
-여기서는  MAIN보관소를 포함한 보관소의 정보들과 하나의 보관소 밑에 세부보관소의 정보까지 보여준다
(id와 name,type)
(id와 name)
2.세부 보관소 상품 카테고리별 필터 단건 조회 API 완성 (필터 기능까지 같이 있음)
-여기서는 세부 보관소의 단건 조회인데 URL에 파라미터 유무를 통해 단건조회와 필터 기능도 같이 들어가 있다
-required속성을 통해 필수 값을 false로 지정하였고 서비스 로직에서 null 유무를 통해 category 유무를 사용하도록 하였다 
3.세부 보관소 상품 단건 조회 API 완성
- 단건 조회는 storageItemId를 통해서 단건으로 상품을 찾는다 
- 컨트롤러 -> 서비스 -> 레포지토리 로직이 아닌
- 컨트롤러 -> 레포지토리 로직으로 작성하였다.