### PR TITLE
Feat: refreshToken Cookie 설정 변경

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -59,7 +59,7 @@ public class SignController {
                 .httpOnly(true)
                 .secure(true)
                 .domain("localhost")
-                .sameSite("None")
+//                .sameSite("None")
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
sameOrigin() 은 https 환경에서 만 작동하므로 생략