### PR TITLE
Feat: refreshToken Cookie 설정 변경

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -58,6 +58,8 @@ public class SignController {
                 .maxAge(COOKIE_EXPIRATION)
                 .httpOnly(true)
                 .secure(true)
+                .domain("localhost")
+                .sameSite("None")
                 .build();
 
         return ResponseEntity.ok()
@@ -69,6 +71,8 @@ public class SignController {
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponse> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken,
                                      @RequestHeader("Authorization") String requestAccessToken) {
+        log.info("accessTokenInHeader : {}", requestAccessToken);
+        log.info("refreshTokenInHeader : {}", requestRefreshToken);
         TokenInfo reissuedTokenDto = signService.reissue(requestAccessToken, requestRefreshToken);
 
         // 토큰 재발급 성공시 RT 저장

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -59,7 +59,7 @@ public class SignController {
                 .httpOnly(true)
                 .secure(true)
                 .domain("localhost")
-                .sameSite("None")
+//                .sameSite("None")
                 .build();
 
         return ResponseEntity.ok()


### PR DESCRIPTION
클라이언트와의 통신을 위해 쿠키에 domain만 설정 하고 sameOrigin() 은 https 환경에서 만 작동하므로 생략