### PR TITLE
Feat: 토큰이 없을 때 필터 로직 및 예외 구현

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/HomeController.java
+++ b/src/main/java/com/challenger/fridge/controller/HomeController.java
@@ -1,0 +1,15 @@
+package com.challenger.fridge.controller;
+
+import com.challenger.fridge.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HomeController {
+
+    @GetMapping("/")
+    public ResponseEntity<ApiResponse> home() {
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+}

--- a/src/main/java/com/challenger/fridge/exception/TokenNotFoundException.java
+++ b/src/main/java/com/challenger/fridge/exception/TokenNotFoundException.java
@@ -1,0 +1,16 @@
+package com.challenger.fridge.exception;
+
+public class TokenNotFoundException extends RuntimeException {
+
+    public TokenNotFoundException() {
+        super();
+    }
+
+    public TokenNotFoundException(String message) {
+        super(message);
+    }
+
+    public TokenNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -36,6 +36,11 @@ public class ExceptionResponseHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("토큰이 만료되었습니다. 다시 로그인해주세요."));
     }
 
+    @ExceptionHandler(TokenNotFoundException.class)
+    public ResponseEntity<ApiResponse> handleTokenNotFoundException() {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("토큰이 없습니다. 다시 시도해주세요"));
+    }
+
    /* @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse> handleException() {
         return ResponseEntity.internalServerError().body(ApiResponse.error("서버에 문제가 발생했습니다."));

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -1,10 +1,12 @@
 package com.challenger.fridge.security;
 
+import com.challenger.fridge.exception.TokenNotFoundException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -18,11 +20,21 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private final String[] allowedUrl = {"/", "/sign-in", "/sign-up", "/swagger-ui/**", "/v3/**"};
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+        log.info("JwtAuthenticationFilter 통과");
+
+        // 토큰이 없을 때 허용된 url 인 경우 다음 필터 진행
+        if (Arrays.asList(allowedUrl).contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         String accessToken = resolveToken(request);
         try {
             if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
@@ -30,6 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 log.info("SecurityContext 에 인증객체 저장");
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Save authentication in SecurityContextHolder.");
+            } else {
+                throw new TokenNotFoundException("토큰이 없습니다. 다시 시도해주세요");
             }
         } catch (Exception e) {
             log.info("JwtFilter - doFilterInternal() 오류 발생");


### PR DESCRIPTION
### **토큰이 없을 때 필터 구현**
- 토큰이 없을 때 허용된 url(회원가입, 로그인, 루트페이지)이면 다음 필터로 진행시켜 토큰을 검증하지 않도록 구현
- 인증이 필요한 url의 경우 토큰 검증 로직을 통해 토큰이 존재하지 않을 때 TokenNotFoundException 던지기
**토큰 없을 때 예외**
- TokenNotFoundException 
- 401 Http Status 로 ExceptionResponseHandler 에서 예외 응답 처리