### PR TITLE
Feat: 로그인 시 쿠키 설정 변경

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -58,7 +58,7 @@ public class SignController {
                 .maxAge(COOKIE_EXPIRATION)
                 .httpOnly(true)
                 .secure(true)
-                .domain("localhost")
+//                .domain("localhost")
 //                .sameSite("None")
                 .build();
 

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
-        log.info("JwtAuthenticationFilter 통과");
+        log.info("JwtAuthenticationFilter 통과 request url : {}",request.getRequestURI());
 
         // 토큰이 없을 때 허용된 url 인 경우 다음 필터 진행
         if (Arrays.asList(allowedUrl).contains(request.getRequestURI())) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,3 @@ jwt:
   secret: 35c21b3de74471b7fd035869767f0cdb0b6adc041c74d252a4913df64ff3d3ec
   access-token-validity-in-seconds: 1800 # 30분
   refresh-token-validity-in-seconds: 7200 # 2시간
-
-server:
-  port: 80


### PR DESCRIPTION
### **responseCookie 설정**
- 로컬에서 postman 로그인 요청시 cookies에 refreshToken 이 잘 응답되지만 ec2로 요청시 cookies에 refreshToken이 응답이 안 되는 문제 발생
- domain 은 쿠키를 생성한 도메인을 뜻하므로 설정에서 제외
- 클라이언트에서 서버로 쿠키를 전송할 때, 동일 출처 정책(same-origin policy)에 따라 도메인이 일치해야 한다. 따라서 서버가 클라이언트로 쿠키를 전송할 때 domain 속성을 설정하지 않아도, 도메인이 일치하는 경우에는 쿠키가 클라이언트에 의해 저장된다.