### PR TITLE
Chore : 스웨거 https 설정 및 정적 자원설정

### DIFF
--- a/src/main/java/com/challenger/fridge/FridgeApplication.java
+++ b/src/main/java/com/challenger/fridge/FridgeApplication.java
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfi
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
-//@OpenAPIDefinition(servers = {@Server(url = "https://naenggeul.life", description = "도메인 설명")})
+@OpenAPIDefinition(servers = {@Server(url = "https://naenggeul.life", description = "도메인 설명")})
 @SpringBootApplication
 @ComponentScan(excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com\\.challenger\\.fridge\\.util\\..*"))
 public class FridgeApplication {

--- a/src/main/java/com/challenger/fridge/security/SecurityConfig.java
+++ b/src/main/java/com/challenger/fridge/security/SecurityConfig.java
@@ -2,11 +2,13 @@ package com.challenger.fridge.security;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -25,6 +27,12 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationEntryPoint entryPoint;
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring()
+                .requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {


### PR DESCRIPTION
### 스웨거 https 적용
- fridgeApplication 의 @OpenApiDefinition 적용
- 로컬에서 진행할 떄는 해당 애노테이션을 제외하면 된다.
### 정적 자원 설정
- ec2 서버의 정적 자원에 대한 요청이 지속되어 TokenNotFoundException이 지속적으로 발생하는 문제
- SecurityConfig에서 정적 자원에 대해서는 보안 적용을 하지 않도록 설정
