### PR TITLE
Feature : 장바구니에 상품 추가 및 장바구니 조회 로직

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -1,0 +1,27 @@
+package com.challenger.fridge.controller;
+
+import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.service.CartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/cart")
+@RestController
+@RequiredArgsConstructor
+public class CartController {
+
+    private final CartService cartService;
+
+    @GetMapping("/items")
+    public ResponseEntity<ApiResponse> cartItemList(@AuthenticationPrincipal User user) {
+        String email = user.getUsername();
+        CartResponse cartResponse = cartService.findItems(email);
+        return ResponseEntity.ok(ApiResponse.success(cartResponse));
+    }
+}

--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -8,6 +8,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,10 +20,17 @@ public class CartController {
 
     private final CartService cartService;
 
-    @GetMapping("/items")
+    @GetMapping
     public ResponseEntity<ApiResponse> cartItemList(@AuthenticationPrincipal User user) {
         String email = user.getUsername();
         CartResponse cartResponse = cartService.findItems(email);
         return ResponseEntity.ok(ApiResponse.success(cartResponse));
+    }
+
+    @PostMapping("/items/{itemId}")
+    public ResponseEntity<ApiResponse> addItemInCart(@PathVariable Long itemId, @AuthenticationPrincipal User user) {
+        String email = user.getUsername();
+        cartService.addItem(email, itemId);
+        return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/challenger/fridge/controller/SignController.java
+++ b/src/main/java/com/challenger/fridge/controller/SignController.java
@@ -51,7 +51,7 @@ public class SignController {
 
     @Operation(summary = "로그인")
     @PostMapping("/sign-in")
-    public ResponseEntity<ApiResponse> signUp(@RequestBody SignInRequest request) {
+    public ResponseEntity<ApiResponse> signIn(@RequestBody SignInRequest request) {
         TokenInfo tokenInfo = signService.signIn(request);
 
         HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenInfo.getRefreshToken())

--- a/src/main/java/com/challenger/fridge/domain/Cart.java
+++ b/src/main/java/com/challenger/fridge/domain/Cart.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.domain;
 
 import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.*;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -9,10 +10,13 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Cart {
 
     @Id @GeneratedValue
@@ -22,4 +26,12 @@ public class Cart {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public static Cart createCart() {
+        return new Cart();
+    }
+
+    public void allocateMember(Member member) {
+        this.member = member;
+    }
 }

--- a/src/main/java/com/challenger/fridge/domain/Cart.java
+++ b/src/main/java/com/challenger/fridge/domain/Cart.java
@@ -9,7 +9,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,6 +29,9 @@ public class Cart {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "cart")
+    private List<CartItem> cartItemList = new ArrayList<>();
 
     public static Cart createCart() {
         return new Cart();

--- a/src/main/java/com/challenger/fridge/domain/CartItem.java
+++ b/src/main/java/com/challenger/fridge/domain/CartItem.java
@@ -30,6 +30,16 @@ public class CartItem {
     @JoinColumn(name = "item_id")
     private Item item;
 
-    private Long count;
+//    private Long count;
 
+    protected CartItem(Cart cart, Item item) {
+        this.cart = cart;
+        this.item = item;
+    }
+
+    public static CartItem createCartItem(Cart cart, Item item) {
+        CartItem cartItem = new CartItem(cart, item);
+        cart.getCartItemList().add(cartItem);
+        return cartItem;
+    }
 }

--- a/src/main/java/com/challenger/fridge/domain/Member.java
+++ b/src/main/java/com/challenger/fridge/domain/Member.java
@@ -39,7 +39,10 @@ public class Member {
     private LocalDateTime createdAt;
 
     @OneToMany(mappedBy = "member")
-    public List<Storage> storageList=new ArrayList<>();
+    private List<Storage> storageList = new ArrayList<>();
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
+    private Cart cart;
 
     public static Member from(SignUpRequest request, PasswordEncoder encoder) {
         return Member.builder()
@@ -49,5 +52,22 @@ public class Member {
                 .role(MemberRole.ROLE_USER)
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public static Member from(SignUpRequest request, PasswordEncoder encoder, Cart cart) {
+        Member member = Member.builder()
+                .email(request.getEmail())
+                .password(encoder.encode(request.getPassword()))
+                .name(request.getName())
+                .role(MemberRole.ROLE_USER)
+                .createdAt(LocalDateTime.now())
+                .cart(cart)
+                .build();
+        cart.allocateMember(member);
+        return member;
+    }
+
+    public void allocateCart(Cart cart) {
+        this.cart = cart;
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemsResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemsResponse.java
@@ -1,0 +1,23 @@
+package com.challenger.fridge.dto.cart;
+
+import com.challenger.fridge.domain.CartItem;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartItemsResponse {
+
+    private Long cartItemId;
+    private Long itemId;
+    private String itemName;
+
+//    private String subCategoryName;
+//    private String mainCategoryName;
+
+    public CartItemsResponse(CartItem cartItem) {
+        this.cartItemId = cartItem.getId();
+        this.cartItemId = cartItem.getItem().getId();
+        this.itemName = cartItem.getItem().getItemName();
+    }
+}

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemsResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemsResponse.java
@@ -11,13 +11,12 @@ public class CartItemsResponse {
     private Long cartItemId;
     private Long itemId;
     private String itemName;
-
-//    private String subCategoryName;
-//    private String mainCategoryName;
+    private String subCategoryName;
 
     public CartItemsResponse(CartItem cartItem) {
         this.cartItemId = cartItem.getId();
-        this.cartItemId = cartItem.getItem().getId();
+        this.itemId = cartItem.getItem().getId();
         this.itemName = cartItem.getItem().getItemName();
+        this.subCategoryName = cartItem.getItem().getCategory().getCategoryName();
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
@@ -1,7 +1,10 @@
 package com.challenger.fridge.dto.cart;
 
+import static java.util.stream.Collectors.toList;
+
 import com.challenger.fridge.domain.Cart;
 import com.challenger.fridge.domain.CartItem;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -13,10 +16,12 @@ public class CartResponse {
     private Long cartId;
     private List<CartItemsResponse> cartItems;
 
-    public CartResponse(Cart cart) {
-        List<CartItem> cartItemList = cart.getCartItemList();
-        this.count = (long) cartItemList.size();
+    public CartResponse(Cart cart, List<CartItem> cartItemList) {
         this.cartId = cart.getId();
-        cartItemList.forEach(cartItem -> cartItems.add(new CartItemsResponse(cartItem)));
+        this.count = (long) cartItemList.size();
+        this.cartItems = cartItemList.stream()
+                .map(CartItemsResponse::new)
+                .collect(toList());
+
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
@@ -1,0 +1,22 @@
+package com.challenger.fridge.dto.cart;
+
+import com.challenger.fridge.domain.Cart;
+import com.challenger.fridge.domain.CartItem;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartResponse {
+    private Long count;
+    private Long cartId;
+    private List<CartItemsResponse> cartItems;
+
+    public CartResponse(Cart cart) {
+        List<CartItem> cartItemList = cart.getCartItemList();
+        this.count = (long) cartItemList.size();
+        this.cartId = cart.getId();
+        cartItemList.forEach(cartItem -> cartItems.add(new CartItemsResponse(cartItem)));
+    }
+}

--- a/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
@@ -1,0 +1,7 @@
+package com.challenger.fridge.repository;
+
+import com.challenger.fridge.domain.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+}

--- a/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
@@ -1,7 +1,14 @@
 package com.challenger.fridge.repository;
 
 import com.challenger.fridge.domain.CartItem;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    @Query("select ci from CartItem ci join fetch ci.item i"
+            + " join fetch  i.category"
+            + " where ci.id = :id")
+    CartItem findItemsById(@Param("id") Long id);
 }

--- a/src/main/java/com/challenger/fridge/repository/CartRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartRepository.java
@@ -12,7 +12,7 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("select c from Cart c join fetch c.member where c.member.email = :email")
     Optional<Cart> findByMemberEmail(@Param("email") String email);
 
-    @Query("select c from Cart c "
+    @Query("select distinct c from Cart c "
             + " join fetch c.member m"
             + " join fetch c.cartItemList ci"
             + " join fetch ci.item i"

--- a/src/main/java/com/challenger/fridge/repository/CartRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartRepository.java
@@ -1,0 +1,14 @@
+package com.challenger.fridge.repository;
+
+import com.challenger.fridge.domain.Cart;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    @Query("select c from Cart c join fetch c.member where c.member.email = :email")
+    Optional<Cart> findByMemberEmail(@Param("email") String email);
+
+}

--- a/src/main/java/com/challenger/fridge/repository/CartRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartRepository.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.repository;
 
 import com.challenger.fridge.domain.Cart;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +12,10 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("select c from Cart c join fetch c.member where c.member.email = :email")
     Optional<Cart> findByMemberEmail(@Param("email") String email);
 
+    @Query("select c from Cart c "
+            + " join fetch c.member m"
+            + " join fetch c.cartItemList ci"
+            + " join fetch ci.item i"
+            + " where m.email = :email")
+    List<Cart> findItemsByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/challenger/fridge/repository/CartRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartRepository.java
@@ -12,10 +12,4 @@ public interface CartRepository extends JpaRepository<Cart, Long> {
     @Query("select c from Cart c join fetch c.member where c.member.email = :email")
     Optional<Cart> findByMemberEmail(@Param("email") String email);
 
-    @Query("select distinct c from Cart c "
-            + " join fetch c.member m"
-            + " join fetch c.cartItemList ci"
-            + " join fetch ci.item i"
-            + " where m.email = :email")
-    List<Cart> findItemsByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/challenger/fridge/repository/MemberRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/MemberRepository.java
@@ -10,4 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     public Optional<Member> findByEmail(String email);
 
+    void deleteByEmail(String email);
 }

--- a/src/main/java/com/challenger/fridge/service/CartService.java
+++ b/src/main/java/com/challenger/fridge/service/CartService.java
@@ -9,8 +9,10 @@ import com.challenger.fridge.repository.CartRepository;
 import com.challenger.fridge.repository.ItemRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CartService {
@@ -27,13 +29,10 @@ public class CartService {
         return new CartResponse(cartList.get(0));
     }
 
-    public void addItem(String email, Long itemId) {
+    public Long addItem(String email, Long itemId) {
         // 장바구니를 찾는다
-        List<Cart> cartList = cartRepository.findItemsByEmail(email);
-        if(cartList.size() != 1) {
-            throw new IllegalArgumentException("장바구니를 확인할 수 없습니다. 다시 시도해주세요");
-        }
-        Cart cart = cartList.get(0);
+        Cart cart = cartRepository.findByMemberEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니를 찾을 수 없습니다."));
 
         // 이미 있는 상품은 추가하지 않아도 된다. -> "해당 상품은 장바구니에 있습니다." 메시지
         List<CartItem> cartItemList = cart.getCartItemList();
@@ -50,5 +49,6 @@ public class CartService {
         // 장바구니에 상품을 추가한다
         CartItem cartItem = CartItem.createCartItem(cart, item);
         cartItemRepository.save(cartItem);
+        return cartItem.getId();
     }
 }

--- a/src/main/java/com/challenger/fridge/service/CartService.java
+++ b/src/main/java/com/challenger/fridge/service/CartService.java
@@ -1,0 +1,23 @@
+package com.challenger.fridge.service;
+
+import com.challenger.fridge.domain.Cart;
+import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.repository.CartRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+
+    public CartResponse findItems(String email) {
+        List<Cart> cartList = cartRepository.findItemsByEmail(email);
+        if(cartList.size() == 0) {
+            throw new IllegalArgumentException("장바구니를 찾을 수 없습니다.");
+        }
+        return new CartResponse(cartList.get(0));
+    }
+}

--- a/src/main/java/com/challenger/fridge/service/CartService.java
+++ b/src/main/java/com/challenger/fridge/service/CartService.java
@@ -1,8 +1,12 @@
 package com.challenger.fridge.service;
 
 import com.challenger.fridge.domain.Cart;
+import com.challenger.fridge.domain.CartItem;
+import com.challenger.fridge.domain.Item;
 import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.CartRepository;
+import com.challenger.fridge.repository.ItemRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +16,8 @@ import org.springframework.stereotype.Service;
 public class CartService {
 
     private final CartRepository cartRepository;
+    private final ItemRepository itemRepository;
+    private final CartItemRepository cartItemRepository;
 
     public CartResponse findItems(String email) {
         List<Cart> cartList = cartRepository.findItemsByEmail(email);
@@ -19,5 +25,30 @@ public class CartService {
             throw new IllegalArgumentException("장바구니를 찾을 수 없습니다.");
         }
         return new CartResponse(cartList.get(0));
+    }
+
+    public void addItem(String email, Long itemId) {
+        // 장바구니를 찾는다
+        List<Cart> cartList = cartRepository.findItemsByEmail(email);
+        if(cartList.size() != 1) {
+            throw new IllegalArgumentException("장바구니를 확인할 수 없습니다. 다시 시도해주세요");
+        }
+        Cart cart = cartList.get(0);
+
+        // 이미 있는 상품은 추가하지 않아도 된다. -> "해당 상품은 장바구니에 있습니다." 메시지
+        List<CartItem> cartItemList = cart.getCartItemList();
+        List<CartItem> collect = cartItemList.stream()
+                .filter(cartItem -> cartItem.getItem().getId().equals(itemId)).toList();
+        if (!collect.isEmpty()) {
+            throw new IllegalArgumentException("해당 상품은 장바구니에 있습니다.");
+        }
+
+        // 상품을 찾는다
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다. 다시 시도해주세요"));
+
+        // 장바구니에 상품을 추가한다
+        CartItem cartItem = CartItem.createCartItem(cart, item);
+        cartItemRepository.save(cartItem);
     }
 }

--- a/src/main/java/com/challenger/fridge/service/SignService.java
+++ b/src/main/java/com/challenger/fridge/service/SignService.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.service;
 
 import com.challenger.fridge.config.RedisService;
+import com.challenger.fridge.domain.Cart;
 import com.challenger.fridge.domain.Member;
 import com.challenger.fridge.dto.sign.SignInRequest;
 import com.challenger.fridge.dto.sign.SignInResponse;
@@ -43,7 +44,6 @@ public class SignService {
             throw new IllegalArgumentException("이미 사용중인 이메일입니다.");
         }
         return true;
-//        return memberRepository.existsByEmail(email);
     }
 
     /**
@@ -51,7 +51,8 @@ public class SignService {
      */
     @Transactional
     public SignUpResponse registerMember(SignUpRequest request) {
-        Member member = memberRepository.save(Member.from(request, encoder));
+        Cart cart = Cart.createCart();
+        Member member = memberRepository.save(Member.from(request, encoder, cart));
         return new SignUpResponse(member.getName());
     }
 

--- a/src/test/java/com/challenger/fridge/repository/CartRepositoryTest.java
+++ b/src/test/java/com/challenger/fridge/repository/CartRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.challenger.fridge.repository;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.challenger.fridge.domain.Cart;
+import com.challenger.fridge.domain.CartItem;
+import com.challenger.fridge.domain.Member;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CartRepositoryTest {
+
+    @Autowired
+    CartRepository cartRepository;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @DisplayName("장바구니 조회")
+    @Test
+    void findCart() {
+        String email = "bbb@test.com";
+
+        Cart cart = cartRepository.findByMemberEmail(email)
+                .orElseThrow(IllegalArgumentException::new);
+        Member member = cart.getMember();
+        Member findMember = memberRepository.findByEmail(email)
+                .orElseThrow(IllegalArgumentException::new);
+
+        assertThat(member.getName()).isEqualTo(findMember.getName());
+    }
+}

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -4,8 +4,14 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.challenger.fridge.domain.CartItem;
 import com.challenger.fridge.domain.Item;
+import com.challenger.fridge.dto.cart.CartItemsResponse;
+import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.ItemRepository;
+import com.challenger.fridge.repository.MemberRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,18 +23,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class CartServiceTest {
 
+    String memberWithThreeItems = "ccc@test.com";
+    String memberWithoutItems = "ddd@test.com";
+    String password = "1234";
+    String memberNameWithItems = "ccc";
+    String memberNameWithoutItems = "ddd";
+
     @Autowired
     CartService cartService;
     @Autowired
     CartItemRepository cartItemRepository;
     @Autowired
     ItemRepository itemRepository;
+    @Autowired
+    SignService signService;
+    @Autowired
+    MemberRepository memberRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        signService.registerMember(new SignUpRequest(memberWithThreeItems, password, memberNameWithItems));
+        cartService.addItem(memberWithThreeItems, 1L);
+        cartService.addItem(memberWithThreeItems, 2L);
+        cartService.addItem(memberWithThreeItems, 3L);
+
+        signService.registerMember(new SignUpRequest(memberWithoutItems, "1234", memberNameWithoutItems));
+    }
 
     @DisplayName("장바구니에 없는 상품 추가")
     @Test
     void addItemNotInCart() {
-        String email = "bbb@test.com";
-        Long itemId = 2L;
+        String email = memberWithThreeItems;
+        Long itemId = 4L;
 
         Long cartItemId = cartService.addItem(email, itemId);
         CartItem cartItem = cartItemRepository.findById(cartItemId)
@@ -43,10 +69,37 @@ class CartServiceTest {
     @DisplayName("장바구니에 있는 상품 추가시 예외 발생")
     @Test
     void addItemInCart() {
-        String email = "bbb@test.com";
-        Long itemId = 1L;
+        String email = memberWithThreeItems;
 
         assertThrows(IllegalArgumentException.class,
-                () -> cartService.addItem(email, itemId));
+                () -> cartService.addItem(email, 1L));
+        assertThrows(IllegalArgumentException.class,
+                () -> cartService.addItem(email, 2L));
+        assertThrows(IllegalArgumentException.class,
+                () -> cartService.addItem(email, 3L));
+    }
+
+    @DisplayName("장바구니 상품 조회 - 상품이 있는 장바구니")
+    @Test
+    void findCartItems() {
+        String emailWithItems = memberWithThreeItems;
+
+        CartResponse cartResponse = cartService.findItems(emailWithItems);
+        List<CartItemsResponse> itemsResponses = cartResponse.getCartItems();
+
+        assertEquals(3, cartResponse.getCount());
+        assertEquals(1, itemsResponses.get(0).getItemId());
+        assertEquals(2, itemsResponses.get(1).getItemId());
+        assertEquals(3, itemsResponses.get(2).getItemId());
+    }
+
+    @DisplayName("장바구니 상품 조회 - 상품이 없는 장바구니")
+    @Test
+    void findCartWithoutItems() {
+        String emailWithoutItems = memberWithoutItems;
+
+        CartResponse cartResponseWithoutItems = cartService.findItems(emailWithoutItems);
+
+        assertEquals(0, cartResponseWithoutItems.getCount());
     }
 }

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -1,0 +1,52 @@
+package com.challenger.fridge.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.challenger.fridge.domain.CartItem;
+import com.challenger.fridge.domain.Item;
+import com.challenger.fridge.repository.CartItemRepository;
+import com.challenger.fridge.repository.ItemRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CartServiceTest {
+
+    @Autowired
+    CartService cartService;
+    @Autowired
+    CartItemRepository cartItemRepository;
+    @Autowired
+    ItemRepository itemRepository;
+
+    @DisplayName("장바구니에 없는 상품 추가")
+    @Test
+    void addItemNotInCart() {
+        String email = "bbb@test.com";
+        Long itemId = 2L;
+
+        Long cartItemId = cartService.addItem(email, itemId);
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(IllegalArgumentException::new);
+        String itemName = cartItem.getItem().getItemName();
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(IllegalArgumentException::new);
+
+        assertEquals(item.getItemName(), itemName);
+    }
+
+    @DisplayName("장바구니에 있는 상품 추가시 예외 발생")
+    @Test
+    void addItemInCart() {
+        String email = "bbb@test.com";
+        Long itemId = 1L;
+
+        assertThrows(IllegalArgumentException.class,
+                () -> cartService.addItem(email, itemId));
+    }
+}


### PR DESCRIPTION
### **장바구니 초기 설정**
- 회원 가입 시 장바구니를 회원 당 하나씩 할당합니다.
- `Member.from()` 으로 엔티티 생성시 만들어둔 Cart 엔티티를 주입

### **장바구니 상품 추가**
- 상품 추가 시 장바구니에 이미 있는 상품의 경우 "해당 상품은 장바구니에 있습니다." 메시지로 예외를 던집니다.
- 장바구니에 없는 상품의 경우 CartItem을 생성 후 저장합니다.

### **장바구니 조회**
- Cart 엔티티 조회 시 Member 엔티티와 1대1 관계여서 쿼리가 두번 나가는 현상이 발생하기 떄문에 Cart-Member fetch Join 으로 한번에 데이터를 가져옵니다
- Cart-CartItem은 일대다 이므로 데이터를 Lazy Loding으로 가져옵니다.
- CartItem-Item 은 다대일 관계, Item-Category 은 다대일 관계 이므로 fetch Join 으로 한번에 가져와 쿼리가 나가는 빈도를 줄였습니다.

### **장바구니 테스트 - CartServiceTest**
- `@BeforeEach` 애노테이션을 사용하여 장바구니에 3개의 상품을 담은 회원과 상품을 담지 않은 회원을 생성합니다.
- 장바구니 조회 테스트는 각 회원 별로 수행했습니다.
- 장바구니에 상품 추가 테스트는 상품을 담은 회원을 대상으로 수행했습니다.