### PR TITLE
Feautre storage fillter select reversion

### DIFF
--- a/src/main/java/com/challenger/fridge/domain/StorageItem.java
+++ b/src/main/java/com/challenger/fridge/domain/StorageItem.java
@@ -45,7 +45,6 @@ public class StorageItem {
 
     private LocalDate purchaseDate;
 
-
     public void addStorageBox(StorageBox storageBox) {
         this.storageBox = storageBox;
         storageBox.getStorageItemList().add(this);
@@ -73,13 +72,14 @@ public class StorageItem {
     }
 
     /**
-     * storageItem 변경 로직
+     * storageItem 필드 변경 로직
      *
      * @param storageItemUpdateRequest
      */
     //PATCH 메서드로 받아오기 떄문에 어떠한 자원이 넘어오는지는 서비스 로직에서는 알수가 없다 그래서 하나씩 필드마다 NULL체크를 해줘야하는 단점이 있다
     //개선해야할 방안을 찾아봐야한다.
     public void changeStorageItem(StorageItemUpdateRequest storageItemUpdateRequest) {
+
         if (storageItemUpdateRequest.getItemCount() != null) {
             this.quantity = storageItemUpdateRequest.getItemCount();
         }
@@ -92,6 +92,15 @@ public class StorageItem {
         if (storageItemUpdateRequest.getPurchaseDate() != null) {
             this.purchaseDate = storageItemUpdateRequest.getPurchaseDateAsLocalDate();
         }
+    }
+    /**
+     * storageItem 다른 StorageBox로 이동
+     *
+     * @param storageBox
+     */
+    public void moveStorageItem(StorageBox storageBox)
+    {
+        this.storageBox=storageBox;
     }
 
 

--- a/src/main/java/com/challenger/fridge/dto/item/request/StorageItemUpdateRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/item/request/StorageItemUpdateRequest.java
@@ -9,6 +9,8 @@ import java.time.format.DateTimeFormatter;
 
 @Data
 public class StorageItemUpdateRequest {
+    @Schema(description = "이동할 세부 보관소 고유 id")
+    private Long storageBoxId;
     @Schema(description = "수정할 아이템 개수")
     private Long itemCount;
     @Schema(description = "수정할 아이템 설명")

--- a/src/main/java/com/challenger/fridge/repository/StorageBoxRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/StorageBoxRepository.java
@@ -11,17 +11,17 @@ import java.util.Optional;
 
 public interface StorageBoxRepository extends JpaRepository<StorageBox, Long> {
     @Query("select distinct sb from StorageBox sb " +
-            "join fetch sb.storageItemList sl " +
-            "join fetch sl.item i " +
-            "join fetch i.category c " +
+            "left join fetch sb.storageItemList sl " +
+            "left join fetch sl.item i " +
+            "left join fetch i.category c " +
             "where sb.id=:storageBoxId " +
             "and c.categoryName in :categories")
     Optional<StorageBox> findStorageItemsByIdAndCategories(@Param("storageBoxId") Long storageBoxId, @Param("categories") List<String> categories);
 
     @Query("select distinct sb from StorageBox sb " +
-            "join fetch sb.storageItemList sl " +
-            "join fetch sl.item i " +
-            "join fetch i.category c " +
+            "left join fetch sb.storageItemList sl " +
+            "left join fetch sl.item i " +
+            "left join fetch i.category c " +
             "where sb.id=:storageBoxId ")
     Optional<StorageBox> findStorageItemsById(@Param("storageBoxId") Long storageBoxId);
 }

--- a/src/main/java/com/challenger/fridge/service/StorageBoxService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageBoxService.java
@@ -65,16 +65,20 @@ public class StorageBoxService {
     }
 
     @Transactional
-    public void deleteStorageItem(Long storageItemId)
-    {
+    public void deleteStorageItem(Long storageItemId) {
         StorageItem storageItem = storageItemRepository.findById(storageItemId).orElseThrow(() -> new StorageItemNotFoundException("해당 하는 세부 보관소 상품이 없습니다"));
         storageItemRepository.delete(storageItem);
     }
 
     @Transactional
-    public void updateStorageItem(StorageItemUpdateRequest storageItemUpdateRequest,Long storageItemId)
-    {
+    public void updateStorageItem(StorageItemUpdateRequest storageItemUpdateRequest, Long storageItemId) {
         StorageItem storageItem = storageItemRepository.findById(storageItemId).orElseThrow(() -> new StorageItemNotFoundException("해당하는 세부 보관소 상품이 없습니다."));
+        //변경할 세부 보관소 Id값을 받는다 해당 id값에 대한 null 체크 후에 storageItem에서 storageBox를 옮긴다.
+        if (storageItemUpdateRequest.getStorageBoxId() != null) {
+            StorageBox storageBox = storageBoxRepository.findById(storageItemUpdateRequest.getStorageBoxId())
+                    .orElseThrow(() -> new StorageBoxNotFoundException("해당하는 세부 보관소가 없습니다."));
+            storageItem.moveStorageItem(storageBox);
+        }
         storageItem.changeStorageItem(storageItemUpdateRequest);
     }
 


### PR DESCRIPTION
**세부보관소 안에 StorageItem update API** 

- 옮길 StorageBoxId를 받아서 storageBox엔티티를 찾은 후 storageItem의 storageBox를 변경

**세부 보관소 필터 단건 조회**

- 세부 보관소를 단건으로 조회할 때  만약 세부 보관소 엔티티가 있다해도 StorageItem이 없다면 데이터 0개 조회 문제 그래서 
orElseThrow(() -> new StorageBoxNotFoundException("해당 세부 보관소가 없습니다."));
세부 보관소는 있지만 StorageItem 없어서 예외가 발생
**solution**
left join 으로 교체
