### PR TITLE
장바구니 상품 보관소 이동 기능 구현 및 테스트 수정

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -1,8 +1,10 @@
 package com.challenger.fridge.controller;
 
 import com.challenger.fridge.dto.ApiResponse;
+import com.challenger.fridge.dto.cart.CartItemToStorageRequest;
 import com.challenger.fridge.dto.cart.CartResponse;
 import com.challenger.fridge.service.CartService;
+import com.challenger.fridge.service.CartStorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CartController {
 
     private final CartService cartService;
+    private final CartStorageService cartStorageService;
 
     @GetMapping
     public ResponseEntity<ApiResponse> cartItemList(@AuthenticationPrincipal User user) {
@@ -44,6 +48,12 @@ public class CartController {
     @DeleteMapping("/{cartItemId}")
     public ResponseEntity<ApiResponse> deleteItemInCart(@PathVariable Long cartItemId) {
         cartService.deleteItem(cartItemId);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PostMapping("/items")
+    public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemToStorageRequest request) {
+
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -1,7 +1,7 @@
 package com.challenger.fridge.controller;
 
 import com.challenger.fridge.dto.ApiResponse;
-import com.challenger.fridge.dto.cart.CartItemToStorageRequest;
+import com.challenger.fridge.dto.cart.CartItemMoveRequest;
 import com.challenger.fridge.dto.cart.CartResponse;
 import com.challenger.fridge.service.CartService;
 import com.challenger.fridge.service.CartStorageService;
@@ -52,8 +52,8 @@ public class CartController {
     }
 
     @PostMapping("/items")
-    public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemToStorageRequest request) {
-
+    public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemMoveRequest cartItemMoveRequest) {
+        cartStorageService.moveItems(cartItemMoveRequest);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/challenger/fridge/domain/Member.java
+++ b/src/main/java/com/challenger/fridge/domain/Member.java
@@ -44,15 +44,15 @@ public class Member {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL)
     private Cart cart;
 
-    public static Member from(SignUpRequest request, PasswordEncoder encoder) {
-        return Member.builder()
-                .email(request.getEmail())
-                .password(encoder.encode(request.getPassword()))
-                .name(request.getName())
-                .role(MemberRole.ROLE_USER)
-                .createdAt(LocalDateTime.now())
-                .build();
-    }
+//    public static Member from(SignUpRequest request, PasswordEncoder encoder) {
+//        return Member.builder()
+//                .email(request.getEmail())
+//                .password(encoder.encode(request.getPassword()))
+//                .name(request.getName())
+//                .role(MemberRole.ROLE_USER)
+//                .createdAt(LocalDateTime.now())
+//                .build();
+//    }
 
     public static Member from(SignUpRequest request, PasswordEncoder encoder, Cart cart) {
         Member member = Member.builder()
@@ -62,6 +62,7 @@ public class Member {
                 .role(MemberRole.ROLE_USER)
                 .createdAt(LocalDateTime.now())
                 .cart(cart)
+                .storageList(new ArrayList<>())
                 .build();
         cart.allocateMember(member);
         return member;

--- a/src/main/java/com/challenger/fridge/domain/StorageItem.java
+++ b/src/main/java/com/challenger/fridge/domain/StorageItem.java
@@ -62,6 +62,13 @@ public class StorageItem {
         this.purchaseDate = purchaseDate;
     }
 
+    public StorageItem(Long quantity, Item item, StorageBox storageBox) {
+        this.quantity = quantity;
+        this.storageBox = storageBox;
+        this.item = item;
+        this.purchaseDate = LocalDate.now();
+    }
+
     public static StorageItem createStorageItem(StorageItemRequest storageItemRequest, Item item, StorageBox storageBox) {
         StorageItem storageItem = new StorageItem(storageItemRequest.getItemCount()
                 , storageItemRequest.getItemDescription()

--- a/src/main/java/com/challenger/fridge/dto/box/request/StorageBoxSaveRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/box/request/StorageBoxSaveRequest.java
@@ -3,8 +3,10 @@ package com.challenger.fridge.dto.box.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 
+@AllArgsConstructor
 @Data
 @Schema(description = "세부 보관소 추가 Request")
 public class StorageBoxSaveRequest {

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemMoveRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemMoveRequest.java
@@ -6,14 +6,7 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class CartItemToStorageRequest {
+public class CartItemMoveRequest {
     private Long boxId;
     private List<CartItemRequest> cartItemRequests;
-
-    @Data
-    @AllArgsConstructor
-    public static class CartItemRequest {
-        private Long cartItemId;
-        private Long count;
-    }
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemRequest.java
@@ -1,0 +1,11 @@
+package com.challenger.fridge.dto.cart;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartItemRequest {
+    private Long cartItemId;
+    private Long count;
+}

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemToStorageRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemToStorageRequest.java
@@ -1,0 +1,19 @@
+package com.challenger.fridge.dto.cart;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CartItemToStorageRequest {
+    private Long boxId;
+    private List<CartItemRequest> cartItemRequests;
+
+    @Data
+    @AllArgsConstructor
+    public static class CartItemRequest {
+        private Long cartItemId;
+        private Long count;
+    }
+}

--- a/src/main/java/com/challenger/fridge/dto/storage/request/StorageSaveRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/storage/request/StorageSaveRequest.java
@@ -4,9 +4,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "보관소 추가 Request")
 public class StorageSaveRequest {
     @Schema(description = "보관소의 이름")

--- a/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
@@ -3,6 +3,7 @@ package com.challenger.fridge.repository;
 import com.challenger.fridge.domain.CartItem;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,7 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
             + " where m.email = :email")
     List<CartItem> findByEmail(@Param("email") String email);
 
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from CartItem ci where ci.id in :cartItemIdList")
+    void deleteSelectedItems(@Param("cartItemIdList") List<Long> cartItemIdList);
 }

--- a/src/main/java/com/challenger/fridge/service/CartStorageService.java
+++ b/src/main/java/com/challenger/fridge/service/CartStorageService.java
@@ -1,0 +1,47 @@
+package com.challenger.fridge.service;
+
+import com.challenger.fridge.domain.CartItem;
+import com.challenger.fridge.domain.StorageItem;
+import com.challenger.fridge.domain.box.StorageBox;
+import com.challenger.fridge.dto.cart.CartItemToStorageRequest;
+import com.challenger.fridge.dto.cart.CartItemToStorageRequest.CartItemRequest;
+import com.challenger.fridge.repository.CartItemRepository;
+import com.challenger.fridge.repository.StorageBoxRepository;
+import com.challenger.fridge.repository.StorageItemRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CartStorageService {
+
+    private final CartItemRepository cartItemRepository;
+    private final StorageBoxRepository storageBoxRepository;
+    private final StorageItemRepository storageItemRepository;
+
+    @Transactional
+    public void moveItems(CartItemToStorageRequest request) {
+        StorageBox storageBox = storageBoxRepository.findById(request.getBoxId())
+                .orElseThrow(() -> new IllegalArgumentException("세부 보관소를 찾을 수 없습니다."));
+
+        // cartItem 찾고 storageItem 으로 변환해서 저장
+        List<StorageItem> storageItemList = request.getCartItemRequests().stream()
+                .map(r -> {
+                    CartItem cartItem = cartItemRepository.findItemsById(r.getCartItemId());
+                    return new StorageItem(r.getCount(), cartItem.getItem(), storageBox);
+                }).toList();
+
+        // bulk insert
+        storageItemRepository.saveAll(storageItemList);
+
+        // cartItem 삭제
+        List<Long> cartItemIdList = request.getCartItemRequests().stream()
+                .map(CartItemRequest::getCartItemId)
+                .toList();
+        cartItemRepository.deleteAllByIdInBatch(cartItemIdList);
+    }
+}

--- a/src/main/java/com/challenger/fridge/service/CartStorageService.java
+++ b/src/main/java/com/challenger/fridge/service/CartStorageService.java
@@ -3,13 +3,12 @@ package com.challenger.fridge.service;
 import com.challenger.fridge.domain.CartItem;
 import com.challenger.fridge.domain.StorageItem;
 import com.challenger.fridge.domain.box.StorageBox;
-import com.challenger.fridge.dto.cart.CartItemToStorageRequest;
-import com.challenger.fridge.dto.cart.CartItemToStorageRequest.CartItemRequest;
+import com.challenger.fridge.dto.cart.CartItemRequest;
+import com.challenger.fridge.dto.cart.CartItemMoveRequest;
 import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.StorageBoxRepository;
 import com.challenger.fridge.repository.StorageItemRepository;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,7 +23,7 @@ public class CartStorageService {
     private final StorageItemRepository storageItemRepository;
 
     @Transactional
-    public void moveItems(CartItemToStorageRequest request) {
+    public void moveItems(CartItemMoveRequest request) {
         StorageBox storageBox = storageBoxRepository.findById(request.getBoxId())
                 .orElseThrow(() -> new IllegalArgumentException("세부 보관소를 찾을 수 없습니다."));
 
@@ -42,6 +41,6 @@ public class CartStorageService {
         List<Long> cartItemIdList = request.getCartItemRequests().stream()
                 .map(CartItemRequest::getCartItemId)
                 .toList();
-        cartItemRepository.deleteAllByIdInBatch(cartItemIdList);
+        cartItemRepository.deleteSelectedItems(cartItemIdList);
     }
 }

--- a/src/test/java/com/challenger/fridge/repository/CartRepositoryTest.java
+++ b/src/test/java/com/challenger/fridge/repository/CartRepositoryTest.java
@@ -26,7 +26,7 @@ class CartRepositoryTest {
     @DisplayName("장바구니 조회")
     @Test
     void findCart() {
-        String email = "bbb@test.com";
+        String email = "aaa@test.com";
 
         Cart cart = cartRepository.findByMemberEmail(email)
                 .orElseThrow(IllegalArgumentException::new);

--- a/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
@@ -1,0 +1,123 @@
+package com.challenger.fridge.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.challenger.fridge.domain.Item;
+import com.challenger.fridge.domain.Storage;
+import com.challenger.fridge.domain.StorageItem;
+import com.challenger.fridge.domain.box.StorageBox;
+import com.challenger.fridge.dto.cart.CartItemRequest;
+import com.challenger.fridge.dto.cart.CartItemMoveRequest;
+import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.sign.SignUpRequest;
+import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
+import com.challenger.fridge.repository.StorageBoxRepository;
+import com.challenger.fridge.repository.StorageRepository;
+import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CartStorageServiceTest {
+
+    @Autowired SignService signService;
+    @Autowired CartService cartService;
+    @Autowired StorageService storageService;
+    @Autowired EntityManager em;
+    @Autowired StorageRepository storageRepository;
+    @Autowired StorageBoxRepository storageBoxRepository;
+    @Autowired CartStorageService cartStorageService;
+
+    Long storageId;
+    List<Item> itemList = new ArrayList<>();
+    List<Long> cartItemIdList;
+
+    @BeforeEach
+    void setUp() {
+        String email = "jjw@test.com";
+        signService.registerMember(new SignUpRequest("jjw@test.com", "1234", "jjj"));
+        storageId = storageService.saveStorage(new StorageSaveRequest("퍼스트 보관소", 3L, 2L), email);
+        Item item1 = em.createQuery("select i from Item i where i.itemName  = '돼지고기'", Item.class).getSingleResult();
+        Item item2 = em.createQuery("select i from Item i where i.itemName  = '양파'", Item.class).getSingleResult();
+        Item item3 = em.createQuery("select i from Item i where i.itemName  = '대파'", Item.class).getSingleResult();
+        Item item4 = em.createQuery("select i from Item i where i.itemName  = '마늘'", Item.class).getSingleResult();
+        itemList.addAll(Arrays.asList(item1, item2, item3, item4));
+
+        cartItemIdList = itemList.stream()
+                .map(item -> cartService.addItem(email, item.getId())).toList();
+    }
+
+    @DisplayName("장바구니에서 모든 상품을 보관소로 옮기기")
+    @Test
+    void moveItemsToBox() {
+        Storage storage = storageRepository.findById(storageId)
+                .orElseThrow(IllegalArgumentException::new);
+        Long boxId = storage.getStorageBoxList().get(1).getId();
+        CartItemRequest pork = new CartItemRequest(cartItemIdList.get(0), 1L);
+        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1), 2L);
+        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2), 3L);
+        CartItemRequest garlic = new CartItemRequest(cartItemIdList.get(3), 4L);
+        List<CartItemRequest> cartItemRequests = new ArrayList<>();
+        cartItemRequests.add(pork);
+        cartItemRequests.add(onion);
+        cartItemRequests.add(greenOnion);
+        cartItemRequests.add(garlic);
+        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
+
+        cartStorageService.moveItems(cartItemMoveRequest);
+        CartResponse res = cartService.findItems("jjw@test.com");
+        StorageBox storageBox = storageBoxRepository.findStorageItemsById(boxId)
+                .orElseThrow(IllegalArgumentException::new);
+        List<StorageItem> storageItemList = storageBox.getStorageItemList();
+
+        assertThat(res.getCartItems().size()).isEqualTo(0);
+
+        assertThat(storageItemList.get(0).getItem().getItemName()).isEqualTo("돼지고기");
+        assertThat(storageItemList.get(1).getItem().getItemName()).isEqualTo("양파");
+        assertThat(storageItemList.get(2).getItem().getItemName()).isEqualTo("대파");
+        assertThat(storageItemList.get(3).getItem().getItemName()).isEqualTo("마늘");
+
+        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(2);
+        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(3);
+        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(4);
+    }
+
+    @DisplayName("장바구니에서 선택한 상품을 보관소로 옮기기")
+    @Test
+    void moveSelectedItemsToBox() {
+        Storage storage = storageRepository.findById(storageId)
+                .orElseThrow(IllegalArgumentException::new);
+        Long boxId = storage.getStorageBoxList().get(1).getId();
+        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1), 2L);
+        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2), 3L);
+        List<CartItemRequest> cartItemRequests = new ArrayList<>();
+        cartItemRequests.add(onion);
+        cartItemRequests.add(greenOnion);
+        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
+
+        cartStorageService.moveItems(cartItemMoveRequest);
+
+        CartResponse res = cartService.findItems("jjw@test.com");
+        StorageBox storageBox = storageBoxRepository.findStorageItemsById(boxId)
+                .orElseThrow(IllegalArgumentException::new);
+        List<StorageItem> storageItemList = storageBox.getStorageItemList();
+
+        assertThat(res.getCartItems().size()).isEqualTo(2);
+
+        assertThat(storageItemList.get(0).getItem().getItemName()).isEqualTo("양파");
+        assertThat(storageItemList.get(1).getItem().getItemName()).isEqualTo("대파");
+
+        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(2);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(3);
+    }
+
+}


### PR DESCRIPTION
### **기본키 전략**
- 기본키 전략으로 `identity` 로 변경 후 테이블을 재생성했습니다. 
재생성한 테이블은 기존 테스트 코드와 관련되어 있어 테이블에 존재하는 데이터와 상관없이 테스트 메서드 내에서 데이터를 넣어 진행하는 방식으로 변경했습니다.
- CartRepositoryTest 의 장바구니 조회 테스트는 데이터베이스 의존적으로 진행했습니다. Member 엔티티 생성시 Cart 엔티티도 같이 생성하는 방식으로 진행하였기 때문에 회원 이메일을 "aaa@test.com"로 가지는 임시 데이터 삽입 후 수행했습니다.
### **장바구니 상품 보관소 이동 기능 구현 및 테스트**
- CartItemRepository와 StorageItemRepository 를 둘다 사용해야 하는 상황이라서 별도 의 서비스 CartStorageService 생성
- 저장할 세부 보관소를 선택한 뒤 해당 보관소에 상품을 저장한다.
- 그 후 `@Modifying` 을 사용한 bulk Delete 로 쿼리한번에 CartItem delete 수행
