### PR TITLE
Feature storage reversion

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/StorageController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageController.java
@@ -51,6 +51,13 @@ public class StorageController {
         return ApiResponse.success(storageResponse);
     }
 
+    @DeleteMapping("/{storageId}")
+    @Operation(summary = "보관소 삭제", description = "보관소를 삭제한다.")
+    public ApiResponse cancelStorage(@PathVariable("storageId") Long storageId) {
+        storageService.deleteStorage(storageId);
+        return ApiResponse.success(null);
+    }
+
     @PostMapping("/{storageId}/storagebox/new")
     @Operation(summary = "세부 보관소 추가", description = "세부 보관소를 추가한다(사용자가 FRIDGE,FREEZE 둘 중 하나를 선택해서 추가 할 수 있다.")
     public ApiResponse createStorageBox(@Valid @RequestBody StorageBoxSaveRequest storageBoxSaveRequest

--- a/src/main/java/com/challenger/fridge/controller/StorageController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageController.java
@@ -5,6 +5,7 @@ import com.challenger.fridge.dto.box.request.StorageBoxSaveRequest;
 import com.challenger.fridge.dto.box.request.StorageBoxUpdateRequest;
 import com.challenger.fridge.dto.box.response.StorageBoxResponse;
 import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
+import com.challenger.fridge.dto.storage.request.StorageUpdateRequest;
 import com.challenger.fridge.dto.storage.response.StorageResponse;
 import com.challenger.fridge.repository.StorageBoxRepository;
 import com.challenger.fridge.service.StorageService;
@@ -34,6 +35,16 @@ public class StorageController {
         String userEmail = user.getUsername();
         storageService.saveStorage(storageSaveRequest, userEmail);
         return ApiResponse.success(null);
+    }
+
+    @PatchMapping
+    @Operation(summary = "메인 보관소 바꾸기", description = "메인 보관소를 바꿀 수 있다.")
+    public ApiResponse modifyStorage(@RequestBody StorageUpdateRequest storageUpdateRequest
+            , @AuthenticationPrincipal User user) {
+        String userEmail = user.getUsername();
+        storageService.updateStorageStatus(storageUpdateRequest, userEmail);
+        return ApiResponse.success(null);
+
     }
 
     @GetMapping
@@ -66,7 +77,7 @@ public class StorageController {
         return ApiResponse.success(null);
     }
 
-    @PatchMapping("{storageId}/storagebox/{storageBoxId}")
+    @PatchMapping("/{storageId}/storagebox/{storageBoxId}")
     @Operation(summary = "세부 보관소 수정", description = "세부 보관소 이름을 수정한다.")
     public ApiResponse modifyStorageBox(@RequestBody StorageBoxUpdateRequest storageBoxUpdateRequest
             , @PathVariable Long storageBoxId
@@ -79,7 +90,7 @@ public class StorageController {
         return ApiResponse.success(storageBoxRepository.findById(storageBoxId).stream().map(storageBox -> StorageBoxResponse.createStorageBoxResponse(storageBox)));
     }
 
-    @DeleteMapping("{storageId}/storagebox/{storageBoxId}")
+    @DeleteMapping("/{storageId}/storagebox/{storageBoxId}")
     @Operation(summary = "세부 보관소 삭제", description = "세부 보관소를 삭제한다(storageItem들도 모두 삭제 된다.")
     public ApiResponse cancelStorageBox(@PathVariable Long storageId
             , @PathVariable Long storageBoxId) {

--- a/src/main/java/com/challenger/fridge/controller/StorageController.java
+++ b/src/main/java/com/challenger/fridge/controller/StorageController.java
@@ -38,10 +38,17 @@ public class StorageController {
 
     @GetMapping
     @Operation(summary = "보관소 전체 조회", description = "보관소들의 정보들을 전체 조회한다.")
-    public ApiResponse getStorage(@AuthenticationPrincipal User user) {
+    public ApiResponse getStorageList(@AuthenticationPrincipal User user) {
         String userEmail = user.getUsername();
-        List<StorageResponse> storageList = storageService.findStorage(userEmail);
+        List<StorageResponse> storageList = storageService.findStorageList(userEmail);
         return ApiResponse.success(storageList);
+    }
+
+    @GetMapping("/{storageId}")
+    @Operation(summary = "보관소 단건 조회", description = "보관소 정보를 단건 조회한다.")
+    public ApiResponse getStorage(@PathVariable("storageId") Long storageId) {
+        StorageResponse storageResponse = storageService.findStorage(storageId);
+        return ApiResponse.success(storageResponse);
     }
 
     @PostMapping("/{storageId}/storagebox/new")

--- a/src/main/java/com/challenger/fridge/domain/Member.java
+++ b/src/main/java/com/challenger/fridge/domain/Member.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.domain;
 
 import com.challenger.fridge.common.MemberRole;
+import com.challenger.fridge.common.StorageStatus;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import jakarta.persistence.*;
 
@@ -80,4 +81,18 @@ public class Member {
     public void allocateCart(Cart cart) {
         this.cart = cart;
     }
+
+    public void changeMainStorage(Storage storage) {
+        storageList.stream()
+                .filter(mainStorage -> mainStorage.getStatus() == StorageStatus.MAIN)
+                .findFirst()
+                .ifPresent(mainStorage -> {
+                    // 현재 Main 보관소를 찾았으므로 현재 MAIN을 NORMAL로 바꾼다.
+                    mainStorage.changeStorageStatus(StorageStatus.NORMAL);
+
+                });
+        // MAIN으로 바꿀 보관소의 Status를 MAIN으로으로 바꾼다
+        storage.changeStorageStatus(StorageStatus.MAIN);
+    }
+
 }

--- a/src/main/java/com/challenger/fridge/domain/Storage.java
+++ b/src/main/java/com/challenger/fridge/domain/Storage.java
@@ -33,7 +33,7 @@ public class Storage {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "storage", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "storage", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StorageBox> storageBoxList = new ArrayList<>();
 
     public Storage(String name, StorageStatus status, Member member) {

--- a/src/main/java/com/challenger/fridge/domain/Storage.java
+++ b/src/main/java/com/challenger/fridge/domain/Storage.java
@@ -77,12 +77,17 @@ public class Storage {
     //으로 변경 가능성 있음
     public void checkStorageBoxCount(StorageMethod storageMethod) {
         Long boxCount = storageMethod == StorageMethod.FRIDGE ? getStorageBoxFridgeCount() : getStorageBoxFreezeCount();
-        if (boxCount > 10)
-        {
-            throw new StorageBoxLimitExceededException(storageMethod+" 의 개수가 초과하였습니다.");
+        if (boxCount > 10) {
+            throw new StorageBoxLimitExceededException(storageMethod + " 의 개수가 초과하였습니다.");
         }
 
     }
+
+    public void changeStorageStatus(StorageStatus storageStatus) {
+        this.status = storageStatus;
+    }
+
+
 }
 
 

--- a/src/main/java/com/challenger/fridge/domain/box/StorageBox.java
+++ b/src/main/java/com/challenger/fridge/domain/box/StorageBox.java
@@ -34,7 +34,7 @@ public abstract class StorageBox {
     @JoinColumn(name = "storage_id")
     private Storage storage;
 
-    @OneToMany(mappedBy = "storageBox", cascade = CascadeType.REMOVE,orphanRemoval = true)
+    @OneToMany(mappedBy = "storageBox", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<StorageItem> storageItemList = new ArrayList<>();
 
     public StorageBox(String name) {

--- a/src/main/java/com/challenger/fridge/dto/box/request/StorageBoxSaveRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/box/request/StorageBoxSaveRequest.java
@@ -5,8 +5,10 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor
+@NoArgsConstructor
 @Data
 @Schema(description = "세부 보관소 추가 Request")
 public class StorageBoxSaveRequest {

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class SignUpRequest {
-
     private String email;
     private String password;
     private String name;

--- a/src/main/java/com/challenger/fridge/dto/storage/request/StorageUpdateRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/storage/request/StorageUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.challenger.fridge.dto.storage.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+@Schema(description = "보관소 수정 Request")
+public class StorageUpdateRequest {
+    @Schema(description = "메인으로 바꿀 보관소의 고유 값")
+    private Long storageId;
+}

--- a/src/main/java/com/challenger/fridge/exception/CannotDeleteException.java
+++ b/src/main/java/com/challenger/fridge/exception/CannotDeleteException.java
@@ -1,0 +1,7 @@
+package com.challenger.fridge.exception;
+
+public class CannotDeleteException extends RuntimeException {
+    public CannotDeleteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -90,4 +90,9 @@ public class ExceptionResponseHandler {
     public ResponseEntity<ApiResponse> handleStorageBoxNotFoundException(StorageBoxNotFoundException e) {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(e.getMessage()));
     }
+
+    @ExceptionHandler(CannotDeleteException.class)
+    public ResponseEntity<ApiResponse> handleCannotDeleteException(CannotDeleteException e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ApiResponse.error(e.getMessage()));
+    }
 }

--- a/src/main/java/com/challenger/fridge/repository/StorageRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/StorageRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface StorageRepository extends JpaRepository<Storage, Long> {
-    @Query("select s from Storage s join fetch s.storageBoxList where s.member=:member")
+    @Query("select s from Storage s left join fetch s.storageBoxList where s.member=:member")
     List<Storage> findStorageListByMember(@Param("member") Member member);
 
     @Query("select s from Storage s left join fetch s.storageBoxList where s.id=:storageId")

--- a/src/main/java/com/challenger/fridge/repository/StorageRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/StorageRepository.java
@@ -5,6 +5,7 @@ import com.challenger.fridge.domain.Storage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +14,6 @@ public interface StorageRepository extends JpaRepository<Storage, Long> {
     @Query("select s from Storage s join fetch s.storageBoxList where s.member=:member")
     List<Storage> findStorageListByMember(@Param("member") Member member);
 
+    @Query("select s from Storage s left join fetch s.storageBoxList where s.id=:storageId")
+    Optional<Storage> findStorageById(@Param("storageId") Long storageId);
 }

--- a/src/main/java/com/challenger/fridge/service/StorageService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageService.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.service;
 
 
+import com.challenger.fridge.common.StorageStatus;
 import com.challenger.fridge.domain.Member;
 import com.challenger.fridge.domain.Storage;
 import com.challenger.fridge.domain.box.StorageBox;
@@ -86,6 +87,20 @@ public class StorageService {
     public void deleteStorageBox(Long storageBoxId, Long storageId) {
         StorageBox storageBox = storageBoxRepository.findById(storageBoxId).orElseThrow(() -> new StorageBoxNotFoundException("해당하는 세부 보관소가 없습니다."));
         storageBoxRepository.delete(storageBox);
+    }
+
+    @Transactional
+    public void deleteStorage(Long storageId) {
+        Storage storage = storageRepository.findById(storageId).orElseThrow(() -> new StorageNotFoundException("해당하는 보관소가 없습니다."));
+        
+        //메인 냉장고는 삭제할 수 없다 --> 메인 보관소 수정 후 삭제 가능
+        if(storage.getStatus()==StorageStatus.MAIN)
+        {
+            throw new CannotDeleteException("메인 냉장고는 삭제할 수 없습니다.");
+        }
+
+        storageRepository.delete(storage);
+        
     }
 
 }

--- a/src/main/java/com/challenger/fridge/service/StorageService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageService.java
@@ -9,6 +9,7 @@ import com.challenger.fridge.dto.box.request.StorageBoxSaveRequest;
 import com.challenger.fridge.dto.box.request.StorageBoxUpdateRequest;
 import com.challenger.fridge.dto.box.request.StorageMethod;
 import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
+import com.challenger.fridge.dto.storage.request.StorageUpdateRequest;
 import com.challenger.fridge.dto.storage.response.StorageResponse;
 import com.challenger.fridge.exception.*;
 import com.challenger.fridge.repository.MemberRepository;
@@ -60,6 +61,15 @@ public class StorageService {
         return savedstorageBox.getId();
     }
 
+    @Transactional
+    public void updateStorageStatus(StorageUpdateRequest storageUpdateRequest, String userEmail) {
+        Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new UserEmailNotFoundException("해당하는 회원이 없습니다."));
+        if (storageUpdateRequest.getStorageId() != null) {
+            Storage storage = storageRepository.findById(storageUpdateRequest.getStorageId()).orElseThrow(() -> new StorageNotFoundException("해당 하는 냉장고가 없습니다"));
+            member.changeMainStorage(storage);
+        }
+    }
+
     public List<StorageResponse> findStorageList(String userEmail) {
         Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new UserEmailNotFoundException("해당하는 회원이 없습니다."));
         List<Storage> storageListByMember = storageRepository.findStorageListByMember(member);
@@ -92,15 +102,14 @@ public class StorageService {
     @Transactional
     public void deleteStorage(Long storageId) {
         Storage storage = storageRepository.findById(storageId).orElseThrow(() -> new StorageNotFoundException("해당하는 보관소가 없습니다."));
-        
+
         //메인 냉장고는 삭제할 수 없다 --> 메인 보관소 수정 후 삭제 가능
-        if(storage.getStatus()==StorageStatus.MAIN)
-        {
+        if (storage.getStatus() == StorageStatus.MAIN) {
             throw new CannotDeleteException("메인 냉장고는 삭제할 수 없습니다.");
         }
 
         storageRepository.delete(storage);
-        
+
     }
 
 }

--- a/src/main/java/com/challenger/fridge/service/StorageService.java
+++ b/src/main/java/com/challenger/fridge/service/StorageService.java
@@ -59,12 +59,17 @@ public class StorageService {
         return savedstorageBox.getId();
     }
 
-    public List<StorageResponse> findStorage(String userEmail) {
+    public List<StorageResponse> findStorageList(String userEmail) {
         Member member = memberRepository.findByEmail(userEmail).orElseThrow(() -> new UserEmailNotFoundException("해당하는 회원이 없습니다."));
         List<Storage> storageListByMember = storageRepository.findStorageListByMember(member);
         return storageListByMember.stream().map(storage -> new StorageResponse(storage))
                 .collect(Collectors.toList());
 
+    }
+
+    public StorageResponse findStorage(Long storageId) {
+        Storage storage = storageRepository.findStorageById(storageId).orElseThrow(() -> new StorageNotFoundException("해당 하는 보관소가 없습니다."));
+        return new StorageResponse(storage);
     }
 
     @Transactional


### PR DESCRIPTION
**세부 보관소를 모두 삭제하면  보관소가 삭제되는 버그 개선**

- left join으로 해결 완료

**보관소 단건 조회 API 추가**

**보관소 삭제 API 완성**

- 메인 보관소는 삭제할 수 없다 (삭제할려는 보관소가 MAIN 이라면 예외를 던짐)

**메인 보관소 바꾸기 API**

- 메인 보관소를 바꾸는 작업을 API 이다 
- 현재 Member의 MAIN 보관소를 찾아서 NORMAL 로  바꾼다.  
(MEMBER 엔티티에서 진행 도메인 주도 로직과 member의 storageList에서 Main을 찾아야 함
Storage에서 changeStorageStatus 를 통해 바꿈)  
