### PR TITLE
장바구니 상품 조회 API 수정 및 상품 수량 조절 API 구현

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -6,6 +6,7 @@ import com.challenger.fridge.dto.cart.CartResponse;
 import com.challenger.fridge.dto.cart.ItemCountRequest;
 import com.challenger.fridge.service.CartService;
 import com.challenger.fridge.service.CartStorageService;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,6 +28,7 @@ public class CartController {
     private final CartService cartService;
     private final CartStorageService cartStorageService;
 
+    @Operation(summary = "장바구니 조회 API")
     @GetMapping
     public ResponseEntity<ApiResponse> cartItemList(@AuthenticationPrincipal User user) {
         String email = user.getUsername();
@@ -34,6 +36,7 @@ public class CartController {
         return ResponseEntity.ok(ApiResponse.success(cartResponse));
     }
 
+    @Operation(summary = "장바구니에 상품 담기 API")
     @PostMapping("/items/{itemId}")
     public ResponseEntity<ApiResponse> addItemInCart(@PathVariable Long itemId, @AuthenticationPrincipal User user) {
         String email = user.getUsername();
@@ -41,24 +44,28 @@ public class CartController {
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "장바구니의 모든 상품 비우기 API")
     @DeleteMapping
     public ResponseEntity<ApiResponse> deleteAllItemsInCart(@AuthenticationPrincipal User user) {
         cartService.deleteAllItemsInCart(user.getUsername());
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "장바구니 상품 단건 삭제 API")
     @DeleteMapping("/{cartItemId}")
     public ResponseEntity<ApiResponse> deleteItemInCart(@PathVariable Long cartItemId) {
         cartService.deleteItem(cartItemId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "장바구니 상품을 냉장고로 이동 API")
     @PostMapping("/items")
     public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemMoveRequest cartItemMoveRequest) {
         cartStorageService.moveItems(cartItemMoveRequest);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
+    @Operation(summary = "장바구니 상품 수량 조절 API")
     @PatchMapping("/{cartItemId}")
     public ResponseEntity<ApiResponse> changeCartItemCount(@PathVariable Long cartItemId, @RequestBody ItemCountRequest itemCountRequest) {
         cartService.changeItemCount(cartItemId, itemCountRequest);

--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -3,6 +3,7 @@ package com.challenger.fridge.controller;
 import com.challenger.fridge.dto.ApiResponse;
 import com.challenger.fridge.dto.cart.CartItemMoveRequest;
 import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.cart.ItemCountRequest;
 import com.challenger.fridge.service.CartService;
 import com.challenger.fridge.service.CartStorageService;
 import lombok.RequiredArgsConstructor;
@@ -55,6 +56,12 @@ public class CartController {
     @PostMapping("/items")
     public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemMoveRequest cartItemMoveRequest) {
         cartStorageService.moveItems(cartItemMoveRequest);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @PatchMapping("/{cartItemId}")
+    public ResponseEntity<ApiResponse> changeCartItemCount(@PathVariable Long cartItemId, @RequestBody ItemCountRequest itemCountRequest) {
+        cartService.changeItemCount(cartItemId, itemCountRequest);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/challenger/fridge/domain/CartItem.java
+++ b/src/main/java/com/challenger/fridge/domain/CartItem.java
@@ -2,6 +2,7 @@ package com.challenger.fridge.domain;
 
 import static jakarta.persistence.FetchType.*;
 
+import com.challenger.fridge.dto.cart.ItemCountRequest;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -43,5 +44,9 @@ public class CartItem {
         CartItem cartItem = new CartItem(cart, item);
         cart.getCartItemList().add(cartItem);
         return cartItem;
+    }
+
+    public void changeCount(ItemCountRequest itemCountRequest) {
+        this.itemCount = itemCountRequest.getItemCount();
     }
 }

--- a/src/main/java/com/challenger/fridge/domain/CartItem.java
+++ b/src/main/java/com/challenger/fridge/domain/CartItem.java
@@ -31,11 +31,12 @@ public class CartItem {
     @JoinColumn(name = "item_id")
     private Item item;
 
-//    private Long count;
+    private Long itemCount;
 
     protected CartItem(Cart cart, Item item) {
         this.cart = cart;
         this.item = item;
+        this.itemCount = 0L;
     }
 
     public static CartItem createCartItem(Cart cart, Item item) {

--- a/src/main/java/com/challenger/fridge/domain/CartItem.java
+++ b/src/main/java/com/challenger/fridge/domain/CartItem.java
@@ -36,7 +36,7 @@ public class CartItem {
     protected CartItem(Cart cart, Item item) {
         this.cart = cart;
         this.item = item;
-        this.itemCount = 0L;
+        this.itemCount = 1L;
     }
 
     public static CartItem createCartItem(Cart cart, Item item) {

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemRequest.java
@@ -7,5 +7,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class CartItemRequest {
     private Long cartItemId;
-    private Long count;
+//    private Long count;
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemResponse.java
@@ -6,17 +6,19 @@ import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class CartItemsResponse {
+public class CartItemResponse {
 
     private Long cartItemId;
     private Long itemId;
     private String itemName;
+    private Long itemCount;
     private String subCategoryName;
 
-    public CartItemsResponse(CartItem cartItem) {
+    public CartItemResponse(CartItem cartItem) {
         this.cartItemId = cartItem.getId();
         this.itemId = cartItem.getItem().getId();
         this.itemName = cartItem.getItem().getItemName();
+        this.itemCount = cartItem.getItemCount();
         this.subCategoryName = cartItem.getItem().getCategory().getCategoryName();
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartResponse.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.challenger.fridge.domain.Cart;
 import com.challenger.fridge.domain.CartItem;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -14,13 +13,13 @@ import lombok.Data;
 public class CartResponse {
     private Long count;
     private Long cartId;
-    private List<CartItemsResponse> cartItems;
+    private List<CartItemResponse> cartItems;
 
     public CartResponse(Cart cart, List<CartItem> cartItemList) {
         this.cartId = cart.getId();
         this.count = (long) cartItemList.size();
         this.cartItems = cartItemList.stream()
-                .map(CartItemsResponse::new)
+                .map(CartItemResponse::new)
                 .collect(toList());
 
     }

--- a/src/main/java/com/challenger/fridge/dto/cart/ItemCountRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/ItemCountRequest.java
@@ -1,5 +1,7 @@
 package com.challenger.fridge.dto.cart;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,5 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ItemCountRequest {
 
+    @NotNull(message = "상품 수량을 입력해주세요")
+    @Min(value = 0, message = "상품 수량은 1개 이상이어야 합니다.")
     private Long itemCount;
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/ItemCountRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/ItemCountRequest.java
@@ -1,0 +1,11 @@
+package com.challenger.fridge.dto.cart;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ItemCountRequest {
+
+    private Long itemCount;
+}

--- a/src/main/java/com/challenger/fridge/service/CartService.java
+++ b/src/main/java/com/challenger/fridge/service/CartService.java
@@ -39,9 +39,9 @@ public class CartService {
 
         // 이미 있는 상품은 추가하지 않아도 된다. -> "해당 상품은 장바구니에 있습니다." 메시지
         List<CartItem> cartItemList = cart.getCartItemList();
-        List<CartItem> collect = cartItemList.stream()
+        List<CartItem> duplicateCartItem = cartItemList.stream()
                 .filter(cartItem -> cartItem.getItem().getId().equals(itemId)).toList();
-        if (!collect.isEmpty()) {
+        if (!duplicateCartItem.isEmpty()) {
             throw new IllegalArgumentException("해당 상품은 장바구니에 있습니다.");
         }
 

--- a/src/main/java/com/challenger/fridge/service/CartService.java
+++ b/src/main/java/com/challenger/fridge/service/CartService.java
@@ -4,6 +4,7 @@ import com.challenger.fridge.domain.Cart;
 import com.challenger.fridge.domain.CartItem;
 import com.challenger.fridge.domain.Item;
 import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.cart.ItemCountRequest;
 import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.CartRepository;
 import com.challenger.fridge.repository.ItemRepository;
@@ -66,4 +67,11 @@ public class CartService {
         cartItemRepository.deleteById(cartItemId);
     }
 
+    @Transactional
+    public Long changeItemCount(Long cartItemId, ItemCountRequest itemCountRequest) {
+        CartItem cartItem = cartItemRepository.findById(cartItemId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니에서 해당 상품을 찾을 수 없습니다."));
+        cartItem.changeCount(itemCountRequest);
+        return cartItem.getId();
+    }
 }

--- a/src/main/java/com/challenger/fridge/service/CartStorageService.java
+++ b/src/main/java/com/challenger/fridge/service/CartStorageService.java
@@ -31,7 +31,7 @@ public class CartStorageService {
         List<StorageItem> storageItemList = request.getCartItemRequests().stream()
                 .map(r -> {
                     CartItem cartItem = cartItemRepository.findItemsById(r.getCartItemId());
-                    return new StorageItem(r.getCount(), cartItem.getItem(), storageBox);
+                    return new StorageItem(cartItem.getItemCount(), cartItem.getItem(), storageBox);
                 }).toList();
 
         // bulk insert

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.challenger.fridge.domain.CartItem;
 import com.challenger.fridge.domain.Item;
-import com.challenger.fridge.dto.cart.CartItemsResponse;
+import com.challenger.fridge.dto.cart.CartItemResponse;
 import com.challenger.fridge.dto.cart.CartResponse;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.repository.CartItemRepository;
@@ -14,7 +14,6 @@ import com.challenger.fridge.repository.MemberRepository;
 import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -90,7 +89,7 @@ class CartServiceTest {
         String emailWithItems = memberWithThreeItems;
 
         CartResponse cartResponse = cartService.findItems(emailWithItems);
-        List<CartItemsResponse> itemsResponses = cartResponse.getCartItems();
+        List<CartItemResponse> itemsResponses = cartResponse.getCartItems();
 
         assertEquals(3, cartResponse.getCount());
         assertEquals(1, itemsResponses.get(0).getItemId());

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -7,6 +7,7 @@ import com.challenger.fridge.domain.CartItem;
 import com.challenger.fridge.domain.Item;
 import com.challenger.fridge.dto.cart.CartItemResponse;
 import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.cart.ItemCountRequest;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.ItemRepository;
@@ -133,5 +134,19 @@ class CartServiceTest {
 
         assertThrows(NoSuchElementException.class,
                 () -> cartItemRepository.findById(cartItemId).get());
+    }
+
+    @DisplayName("장바구니에 담긴 상품 수량 조절")
+    @Test
+    void changeItemCount() {
+        String emailWithThreeItems = memberWithThreeItems;
+        Long cartItemId = cartService.addItem(emailWithThreeItems, 4L);
+        ItemCountRequest itemCountRequest = new ItemCountRequest(5L);
+
+        Long fiveCartItemId = cartService.changeItemCount(cartItemId, itemCountRequest);
+        CartItem cartItem = cartItemRepository.findById(fiveCartItemId)
+                .orElseThrow(IllegalArgumentException::new);
+        
+        assertThat(cartItem.getItemCount()).isEqualTo(5L);
     }
 }

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -68,6 +68,7 @@ class CartServiceTest {
                 .orElseThrow(IllegalArgumentException::new);
 
         assertEquals(item.getItemName(), itemName);
+        assertEquals(cartItem.getItemCount(), 1L);
     }
 
     @DisplayName("장바구니에 있는 상품 추가시 예외 발생")

--- a/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
@@ -65,10 +65,10 @@ class CartStorageServiceTest {
                 .orElseThrow(IllegalArgumentException::new);
         Long boxId = storage.getStorageBoxList().get(1).getId();
         List<CartItemRequest> cartItemRequests = new ArrayList<>();
-        CartItemRequest pork = new CartItemRequest(cartItemIdList.get(0), 1L);
-        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1), 2L);
-        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2), 3L);
-        CartItemRequest garlic = new CartItemRequest(cartItemIdList.get(3), 4L);
+        CartItemRequest pork = new CartItemRequest(cartItemIdList.get(0));
+        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1));
+        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2));
+        CartItemRequest garlic = new CartItemRequest(cartItemIdList.get(3));
         cartItemRequests.add(pork);
         cartItemRequests.add(onion);
         cartItemRequests.add(greenOnion);
@@ -91,9 +91,9 @@ class CartStorageServiceTest {
         assertThat(storageItemList.get(3).getItem().getItemName()).isEqualTo("마늘");
 
         assertThat(storageItemList.get(0).getQuantity()).isEqualTo(1);
-        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(2);
-        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(3);
-        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(4);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(1);
     }
 
     @DisplayName("장바구니에서 선택한 상품을 보관소로 옮기기")
@@ -104,8 +104,8 @@ class CartStorageServiceTest {
                 .orElseThrow(IllegalArgumentException::new);
         Long boxId = storage.getStorageBoxList().get(1).getId();
         List<CartItemRequest> cartItemRequests = new ArrayList<>();
-        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1), 2L);
-        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2), 3L);
+        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1));
+        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2));
         cartItemRequests.add(onion);
         cartItemRequests.add(greenOnion);
         CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
@@ -123,8 +123,8 @@ class CartStorageServiceTest {
         assertThat(storageItemList.get(0).getItem().getItemName()).isEqualTo("양파");
         assertThat(storageItemList.get(1).getItem().getItemName()).isEqualTo("대파");
 
-        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(2);
-        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(3);
+        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(1);
     }
 
     private Item findItem(String itemName) {

--- a/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
@@ -9,6 +9,7 @@ import com.challenger.fridge.domain.box.StorageBox;
 import com.challenger.fridge.dto.cart.CartItemRequest;
 import com.challenger.fridge.dto.cart.CartItemMoveRequest;
 import com.challenger.fridge.dto.cart.CartResponse;
+import com.challenger.fridge.dto.cart.ItemCountRequest;
 import com.challenger.fridge.dto.sign.SignUpRequest;
 import com.challenger.fridge.dto.storage.request.StorageSaveRequest;
 import com.challenger.fridge.repository.StorageBoxRepository;
@@ -76,6 +77,11 @@ class CartStorageServiceTest {
         CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
 
         //when
+        cartService.changeItemCount(cartItemIdList.get(0), new ItemCountRequest(2L));
+        cartService.changeItemCount(cartItemIdList.get(1), new ItemCountRequest(4L));
+        cartService.changeItemCount(cartItemIdList.get(2), new ItemCountRequest(6L));
+        cartService.changeItemCount(cartItemIdList.get(3), new ItemCountRequest(8L));
+
         cartStorageService.moveItems(cartItemMoveRequest);
         CartResponse cartResponse = cartService.findItems("jjw@test.com");
         StorageBox storageBox = storageBoxRepository.findStorageItemsById(boxId)
@@ -90,10 +96,10 @@ class CartStorageServiceTest {
         assertThat(storageItemList.get(2).getItem().getItemName()).isEqualTo("대파");
         assertThat(storageItemList.get(3).getItem().getItemName()).isEqualTo("마늘");
 
-        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(1);
-        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(1);
-        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(1);
-        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(2);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(4);
+        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(6);
+        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(8);
     }
 
     @DisplayName("장바구니에서 선택한 상품을 보관소로 옮기기")


### PR DESCRIPTION
### **장바구니 상품 조회 API 수정**
- 기존에 장바구니에 담긴 상품은 수량이 없었고 상품을 보관소로 옮길 때 수량을 요청에 담아와 처리하는 방식이었습니다.
- 검색탭에서 상품을 장바구니에 담을 때 상품 기본 수량을 1개로 지정하였습니다.
- CartItem 엔티티의 itemCount 필드를 추가하고 장바구니 조회시 상품 별 개수를 볼 수 있도록 로직을 변경하였습니다.
### **장바구니 상품 수량 조절 API 구현**
- 장바구니에서 상품 수량 조절을 할 수 있게 하였습니다.

**api 수정 및 변경으로 인한 테스트 메서드 또한 수정하였습니다.**