### PR TITLE
Feature : 장바구니 상품 보관소 이동, 조회 API 수정 및 테스트 수정

### DIFF
--- a/src/main/java/com/challenger/fridge/controller/CartController.java
+++ b/src/main/java/com/challenger/fridge/controller/CartController.java
@@ -61,14 +61,17 @@ public class CartController {
 
     @Operation(summary = "장바구니 상품을 냉장고로 이동 API")
     @PostMapping("/items")
-    public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemMoveRequest cartItemMoveRequest) {
-        cartStorageService.moveItems(cartItemMoveRequest);
+    public ResponseEntity<ApiResponse> moveItemToStorage(@RequestBody CartItemMoveRequest cartItemMoveRequest,
+                                                         @AuthenticationPrincipal User user) {
+        cartStorageService.moveItems(cartItemMoveRequest, user.getUsername());
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 
     @Operation(summary = "장바구니 상품 수량 조절 API")
     @PatchMapping("/{cartItemId}")
-    public ResponseEntity<ApiResponse> changeCartItemCount(@PathVariable Long cartItemId, @Valid @RequestBody ItemCountRequest itemCountRequest) {
+    public ResponseEntity<ApiResponse> changeCartItemCount(@PathVariable Long cartItemId,
+                                                           @Valid @RequestBody ItemCountRequest itemCountRequest) {
+
         cartService.changeItemCount(cartItemId, itemCountRequest);
         return ResponseEntity.ok(ApiResponse.success(null));
     }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemMoveRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemMoveRequest.java
@@ -8,5 +8,5 @@ import lombok.Data;
 @AllArgsConstructor
 public class CartItemMoveRequest {
     private Long boxId;
-    private List<CartItemRequest> cartItemRequests;
+//    private List<CartItemRequest> cartItemRequests;
 }

--- a/src/main/java/com/challenger/fridge/dto/cart/CartItemResponse.java
+++ b/src/main/java/com/challenger/fridge/dto/cart/CartItemResponse.java
@@ -12,6 +12,7 @@ public class CartItemResponse {
     private Long itemId;
     private String itemName;
     private Long itemCount;
+    private Boolean isPurchased;
     private String subCategoryName;
 
     public CartItemResponse(CartItem cartItem) {
@@ -19,6 +20,7 @@ public class CartItemResponse {
         this.itemId = cartItem.getItem().getId();
         this.itemName = cartItem.getItem().getItemName();
         this.itemCount = cartItem.getItemCount();
+        this.isPurchased = cartItem.getIsPurchased();
         this.subCategoryName = cartItem.getItem().getCategory().getCategoryName();
     }
 }

--- a/src/main/java/com/challenger/fridge/dto/member/MemberNicknameRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/member/MemberNicknameRequest.java
@@ -13,6 +13,6 @@ import lombok.NoArgsConstructor;
 public class MemberNicknameRequest {
 
     @NotBlank(message = "새로운 닉네임을 입력해주세요.")
-    @Size(min = 1, max = 8)
+    @Size(min = 1, max = 8, message = "닉네임은 최대 8자입니다.")
     private String nickname;
 }

--- a/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
+++ b/src/main/java/com/challenger/fridge/dto/sign/SignUpRequest.java
@@ -21,6 +21,6 @@ public class SignUpRequest {
     private String password;
 
     @NotBlank(message = "닉네임 입력은 필수 입니다.")
-    @Size(min = 1, max = 8)
+    @Size(min = 1, max = 8, message = "닉네임은 최대 8자입니다.")
     private String nickname;
 }

--- a/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
@@ -21,4 +21,9 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("delete from CartItem ci where ci.id in :cartItemIdList")
     void deleteSelectedItems(@Param("cartItemIdList") List<Long> cartItemIdList);
+
+    @Query("select ci from CartItem ci join fetch ci.cart c"
+            + " join fetch c.member m"
+            + " where m.email = :email and ci.isPurchased = true")
+    List<CartItem> findPurchasedItemByEmail(@Param("email") String email);
 }

--- a/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
+++ b/src/main/java/com/challenger/fridge/repository/CartItemRepository.java
@@ -18,12 +18,12 @@ public interface CartItemRepository extends JpaRepository<CartItem, Long> {
             + " where m.email = :email")
     List<CartItem> findByEmail(@Param("email") String email);
 
-    @Modifying(flushAutomatically = true, clearAutomatically = true)
-    @Query("delete from CartItem ci where ci.id in :cartItemIdList")
-    void deleteSelectedItems(@Param("cartItemIdList") List<Long> cartItemIdList);
-
     @Query("select ci from CartItem ci join fetch ci.cart c"
             + " join fetch c.member m"
             + " where m.email = :email and ci.isPurchased = true")
     List<CartItem> findPurchasedItemByEmail(@Param("email") String email);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query("delete from CartItem ci where ci in :cartItemList")
+    void deleteMovedItemInBatch(@Param("cartItemList") List<CartItem> cartItemList);
 }

--- a/src/main/java/com/challenger/fridge/service/CartStorageService.java
+++ b/src/main/java/com/challenger/fridge/service/CartStorageService.java
@@ -9,6 +9,7 @@ import com.challenger.fridge.repository.CartItemRepository;
 import com.challenger.fridge.repository.StorageBoxRepository;
 import com.challenger.fridge.repository.StorageItemRepository;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,24 +24,31 @@ public class CartStorageService {
     private final StorageItemRepository storageItemRepository;
 
     @Transactional
-    public void moveItems(CartItemMoveRequest request) {
-        StorageBox storageBox = storageBoxRepository.findById(request.getBoxId())
+    public void moveItems(CartItemMoveRequest cartItemMoveRequest, String email) {
+        StorageBox storageBox = storageBoxRepository.findById(cartItemMoveRequest.getBoxId())
                 .orElseThrow(() -> new IllegalArgumentException("세부 보관소를 찾을 수 없습니다."));
 
         // cartItem 찾고 storageItem 으로 변환해서 저장
-        List<StorageItem> storageItemList = request.getCartItemRequests().stream()
-                .map(r -> {
-                    CartItem cartItem = cartItemRepository.findItemsById(r.getCartItemId());
-                    return new StorageItem(cartItem.getItemCount(), cartItem.getItem(), storageBox);
-                }).toList();
+//        List<StorageItem> storageItemList = cartItemMoveRequest.getCartItemRequests().stream()
+//                .map(r -> {
+//                    CartItem cartItem = cartItemRepository.findItemsById(r.getCartItemId());
+//                    return new StorageItem(cartItem.getItemCount(), cartItem.getItem(), storageBox);
+//                }).toList();
+        // cartItem 중 isPurchased 된 데이터만 구하기
+        List<CartItem> cartItemList = cartItemRepository.findPurchasedItemByEmail(email);
+        List<StorageItem> storageItemList = cartItemList.stream()
+                .map(cartItem -> new StorageItem(cartItem.getItemCount(), cartItem.getItem(), storageBox))
+                .collect(Collectors.toList());
 
         // bulk insert
         storageItemRepository.saveAll(storageItemList);
 
         // cartItem 삭제
-        List<Long> cartItemIdList = request.getCartItemRequests().stream()
-                .map(CartItemRequest::getCartItemId)
-                .toList();
-        cartItemRepository.deleteSelectedItems(cartItemIdList);
+//        List<Long> cartItemIdList = cartItemMoveRequest.getCartItemRequests().stream()
+//                .map(CartItemRequest::getCartItemId)
+//                .toList();
+//        cartItemRepository.deleteSelectedItems(cartItemIdList);
+        cartItemRepository.deleteAllInBatch(cartItemList);
+
     }
 }

--- a/src/main/java/com/challenger/fridge/service/CartStorageService.java
+++ b/src/main/java/com/challenger/fridge/service/CartStorageService.java
@@ -28,12 +28,6 @@ public class CartStorageService {
         StorageBox storageBox = storageBoxRepository.findById(cartItemMoveRequest.getBoxId())
                 .orElseThrow(() -> new IllegalArgumentException("세부 보관소를 찾을 수 없습니다."));
 
-        // cartItem 찾고 storageItem 으로 변환해서 저장
-//        List<StorageItem> storageItemList = cartItemMoveRequest.getCartItemRequests().stream()
-//                .map(r -> {
-//                    CartItem cartItem = cartItemRepository.findItemsById(r.getCartItemId());
-//                    return new StorageItem(cartItem.getItemCount(), cartItem.getItem(), storageBox);
-//                }).toList();
         // cartItem 중 isPurchased 된 데이터만 구하기
         List<CartItem> cartItemList = cartItemRepository.findPurchasedItemByEmail(email);
         List<StorageItem> storageItemList = cartItemList.stream()
@@ -44,11 +38,6 @@ public class CartStorageService {
         storageItemRepository.saveAll(storageItemList);
 
         // cartItem 삭제
-//        List<Long> cartItemIdList = cartItemMoveRequest.getCartItemRequests().stream()
-//                .map(CartItemRequest::getCartItemId)
-//                .toList();
-//        cartItemRepository.deleteSelectedItems(cartItemIdList);
-        cartItemRepository.deleteAllInBatch(cartItemList);
-
+        cartItemRepository.deleteMovedItemInBatch(cartItemList);
     }
 }

--- a/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
+++ b/src/test/java/com/challenger/fridge/controller/SignControllerTest.java
@@ -112,10 +112,10 @@ class SignControllerTest {
     void signUpTestWithWrongNickname() throws Exception {
         String email = "jjw@test.com";
         String password = "jjwPassword1!";
-        String wrongNickname = "틀린닉네임";
+        String wrongNickname = "이닉네임은 잘못된 닉네임";
         SignUpRequest requestWithWrongNickname = createSignUpRequest(email, password, wrongNickname);
 
-        ApiResponse apiResponseWithWrongNickname = createApiFailResponse("닉네임은 영어랑 숫자만 가능합니다.");
+        ApiResponse apiResponseWithWrongNickname = createApiFailResponse("닉네임은 최대 8자입니다.");
         String requestJsonWithWrongNickname = objectMapper.writeValueAsString(requestWithWrongNickname);
         String responseJsonWithWrongNickname = objectMapper.writeValueAsString(apiResponseWithWrongNickname);
 

--- a/src/test/java/com/challenger/fridge/service/CartServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartServiceTest.java
@@ -48,11 +48,18 @@ class CartServiceTest {
     @BeforeEach
     void beforeEach() {
         signService.registerMember(new SignUpRequest(memberWithThreeItems, password, memberNameWithItems));
-        cartService.addItem(memberWithThreeItems, 1L);
-        cartService.addItem(memberWithThreeItems, 2L);
-        cartService.addItem(memberWithThreeItems, 3L);
-
         signService.registerMember(new SignUpRequest(memberWithoutItems, "1234", memberNameWithoutItems));
+
+        Long firstCartItemId = cartService.addItem(memberWithThreeItems, 1L);
+        Long secondCartItemId = cartService.addItem(memberWithThreeItems, 2L);
+        Long thirdCartItemId = cartService.addItem(memberWithThreeItems, 3L);
+
+        CartItem firstCartItem = cartItemRepository.findById(firstCartItemId)
+                .orElseThrow(IllegalArgumentException::new);
+        CartItem thirdCartItem = cartItemRepository.findById(thirdCartItemId)
+                .orElseThrow(IllegalArgumentException::new);
+        firstCartItem.changePurchase();
+        thirdCartItem.changePurchase();
     }
 
     @DisplayName("장바구니에 없는 상품 추가")
@@ -94,9 +101,14 @@ class CartServiceTest {
         List<CartItemResponse> itemsResponses = cartResponse.getCartItems();
 
         assertEquals(3, cartResponse.getCount());
+
         assertEquals(1, itemsResponses.get(0).getItemId());
         assertEquals(2, itemsResponses.get(1).getItemId());
         assertEquals(3, itemsResponses.get(2).getItemId());
+
+        assertThat(itemsResponses.get(0).getIsPurchased()).isTrue();
+        assertThat(itemsResponses.get(1).getIsPurchased()).isFalse();
+        assertThat(itemsResponses.get(2).getIsPurchased()).isTrue();
     }
 
     @DisplayName("장바구니 상품 조회 - 상품이 없는 장바구니")

--- a/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
+++ b/src/test/java/com/challenger/fridge/service/CartStorageServiceTest.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,31 +59,22 @@ class CartStorageServiceTest {
                 .map(item -> cartService.addItem(email, item.getId())).toList();
     }
 
-    @DisplayName("장바구니에서 모든 상품을 보관소로 옮기기")
+    @DisplayName("장바구니의 모든 구매 상품을 보관소로 옮기기")
     @Test
     void moveItemsToBox() {
         //given
+        String email = "jjw@test.com";
         Storage storage = storageRepository.findById(storageId)
                 .orElseThrow(IllegalArgumentException::new);
         Long boxId = storage.getStorageBoxList().get(1).getId();
-        List<CartItemRequest> cartItemRequests = new ArrayList<>();
-        CartItemRequest pork = new CartItemRequest(cartItemIdList.get(0));
-        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1));
-        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2));
-        CartItemRequest garlic = new CartItemRequest(cartItemIdList.get(3));
-        cartItemRequests.add(pork);
-        cartItemRequests.add(onion);
-        cartItemRequests.add(greenOnion);
-        cartItemRequests.add(garlic);
-        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
+        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId);
 
         //when
-        cartService.changeItemCount(cartItemIdList.get(0), new ItemCountRequest(2L));
-        cartService.changeItemCount(cartItemIdList.get(1), new ItemCountRequest(4L));
-        cartService.changeItemCount(cartItemIdList.get(2), new ItemCountRequest(6L));
-        cartService.changeItemCount(cartItemIdList.get(3), new ItemCountRequest(8L));
+        cartItemIdList.forEach(cartItemId -> cartService.changeItemPurchase(cartItemId));
+        System.out.println("=================");
+        cartStorageService.moveItems(cartItemMoveRequest, email);
+        System.out.println("=================");
 
-        cartStorageService.moveItems(cartItemMoveRequest);
         CartResponse cartResponse = cartService.findItems("jjw@test.com");
         StorageBox storageBox = storageBoxRepository.findStorageItemsById(boxId)
                 .orElseThrow(IllegalArgumentException::new);
@@ -96,28 +88,29 @@ class CartStorageServiceTest {
         assertThat(storageItemList.get(2).getItem().getItemName()).isEqualTo("대파");
         assertThat(storageItemList.get(3).getItem().getItemName()).isEqualTo("마늘");
 
-        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(2);
-        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(4);
-        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(6);
-        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(8);
+        assertThat(storageItemList.get(0).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(1).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(2).getQuantity()).isEqualTo(1);
+        assertThat(storageItemList.get(3).getQuantity()).isEqualTo(1);
     }
 
-    @DisplayName("장바구니에서 선택한 상품을 보관소로 옮기기")
+    @DisplayName("장바구니에서 일부 상품 구매후 보관소로 옮기기")
     @Test
     void moveSelectedItemsToBox() {
         //given
+        String email = "jjw@test.com";
         Storage storage = storageRepository.findById(storageId)
                 .orElseThrow(IllegalArgumentException::new);
         Long boxId = storage.getStorageBoxList().get(1).getId();
-        List<CartItemRequest> cartItemRequests = new ArrayList<>();
-        CartItemRequest onion = new CartItemRequest(cartItemIdList.get(1));
-        CartItemRequest greenOnion = new CartItemRequest(cartItemIdList.get(2));
-        cartItemRequests.add(onion);
-        cartItemRequests.add(greenOnion);
-        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId, cartItemRequests);
+        Long onionId = cartItemIdList.get(1);
+        Long greenOnionId = cartItemIdList.get(2);
+        CartItemMoveRequest cartItemMoveRequest = new CartItemMoveRequest(boxId);
 
         //when
-        cartStorageService.moveItems(cartItemMoveRequest);
+        cartService.changeItemPurchase(onionId);
+        cartService.changeItemPurchase(greenOnionId);
+        cartStorageService.moveItems(cartItemMoveRequest, email);
+
         CartResponse cartResponse = cartService.findItems("jjw@test.com");
         StorageBox storageBox = storageBoxRepository.findStorageItemsById(boxId)
                 .orElseThrow(IllegalArgumentException::new);


### PR DESCRIPTION
**장바구니에 담긴 상품의 구매 여부를 알려주는 `CartItem`-`isPurchased` 필드 추가에 따른 수정 사항입니다.**
### **장바구니 상품 보관소 이동 API**
- 기존 API는 사용자가 화면에서 선택한 상품만 보관소로 이동하는 로직이었습니다.
- isPurchased 필드 추가로 해당 필드값이 true 인 상품만 보관소로 이동하도록 변경하였습니다.
### **장바구니 상품 조회 API**
- 화면에 구매 여부에 따른 표시가 다르므로 CartResponse 에도 isPurchased 필드를 추가했습니다.
### **테스트 수정**
- SignControllerTest-signUpTestWithWrongNickname() 메서드에서 계속 에러 발생
- 닉네임의 제약 조건은 `@NotBlank` 와 `@Size(min=1, max=8)` 중 닉네임 길이 검증 실패시 에러 메시지가 없어서 발생한 에러였습니다.
- SignUpRequest와 MemberNicknameRequest의 `@Size` validation에 '닉네임은 최대 8자입니다' 에러 메시지를 추가했습니다.