### PR TITLE
Feature: 로그인 및 인증, 인가 예외 적용과 AccessToken 재발급 로직 수정

### DIFF
--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -10,6 +10,7 @@ import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -42,6 +43,11 @@ public class ExceptionResponseHandler {
     @ExceptionHandler(TokenNotFoundException.class)
     public ResponseEntity<ApiResponse> handleTokenNotFoundException() {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("토큰이 없습니다. 다시 시도해주세요"));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse> handleAccessDeniedHandler() {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(ApiResponse.error("접근할 수 없습니다."));
     }
 
    /* @ExceptionHandler(Exception.class)

--- a/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
+++ b/src/main/java/com/challenger/fridge/handler/ExceptionResponseHandler.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,6 +44,11 @@ public class ExceptionResponseHandler {
     @ExceptionHandler(TokenNotFoundException.class)
     public ResponseEntity<ApiResponse> handleTokenNotFoundException() {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(ApiResponse.error("토큰이 없습니다. 다시 시도해주세요"));
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ApiResponse> handleBadCredentialsException(BadCredentialsException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.error("아이디와 비밀번호가 일치하지 않습니다."));
     }
 
     @ExceptionHandler(AccessDeniedException.class)

--- a/src/main/java/com/challenger/fridge/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.challenger.fridge.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver resolver;
+
+    public JwtAccessDeniedHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        resolver.resolveException(request, response, null, accessDeniedException);
+    }
+}

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.challenger.fridge.security;
 
-import com.challenger.fridge.exception.TokenNotFoundException;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -45,16 +44,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Save authentication in SecurityContextHolder.");
             }
-//        } catch (ExpiredJwtException e) {
-//            if (request.getRequestURI().equals("/reissue")) {
-//                log.info("accessToken 만료됨. reissue 시작");
-//                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-//                log.info("SecurityContext 에 인증객체 저장");
-//                SecurityContextHolder.getContext().setAuthentication(authentication);
-//                log.debug("Save authentication in SecurityContextHolder.");
-//            } else {
-//                request.setAttribute("exception", e);
-//            }
+        } catch (ExpiredJwtException e) {
+            if (request.getRequestURI().equals("/reissue")) {
+                log.info("accessToken 만료됨. reissue 시작");
+                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+                log.info("SecurityContext 에 인증객체 저장");
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+                log.debug("Save authentication in SecurityContextHolder.");
+            } else {
+                request.setAttribute("exception", e);
+            }
         } catch (Exception e) {
             log.info("JwtFilter - doFilterInternal() 오류 발생");
             log.info("예외 : {}", e.getClass());

--- a/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/challenger/fridge/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.challenger.fridge.security;
 
 import com.challenger.fridge.exception.TokenNotFoundException;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -38,13 +39,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String accessToken = resolveToken(request);
         try {
             if (accessToken != null && jwtTokenProvider.validateToken(accessToken)) {
+                log.info("accessToken 만료 안됨");
                 Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
                 log.info("SecurityContext 에 인증객체 저장");
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 log.debug("Save authentication in SecurityContextHolder.");
-            } else {
-                throw new TokenNotFoundException("토큰이 없습니다. 다시 시도해주세요");
             }
+//        } catch (ExpiredJwtException e) {
+//            if (request.getRequestURI().equals("/reissue")) {
+//                log.info("accessToken 만료됨. reissue 시작");
+//                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+//                log.info("SecurityContext 에 인증객체 저장");
+//                SecurityContextHolder.getContext().setAuthentication(authentication);
+//                log.debug("Save authentication in SecurityContextHolder.");
+//            } else {
+//                request.setAttribute("exception", e);
+//            }
         } catch (Exception e) {
             log.info("JwtFilter - doFilterInternal() 오류 발생");
             log.info("예외 : {}", e.getClass());

--- a/src/main/java/com/challenger/fridge/security/SecurityConfig.java
+++ b/src/main/java/com/challenger/fridge/security/SecurityConfig.java
@@ -26,6 +26,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationEntryPoint entryPoint;
 
@@ -41,6 +42,7 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .anonymous(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
                         requests.requestMatchers("/members/**", "/reissue", "/cart/**", "/items", "/storagebox/**",
                                         "/storage/**", "/notification/**").authenticated()
@@ -53,7 +55,8 @@ public class SecurityConfig {
                         sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .addFilterBefore(jwtAuthenticationFilter, BasicAuthenticationFilter.class)
-                .exceptionHandling(handler -> handler.authenticationEntryPoint(entryPoint))
+                .exceptionHandling(handler -> handler.authenticationEntryPoint(entryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
                 .build();
     }
 


### PR DESCRIPTION
### **로그인 예외**
- ExceptionResponseHandler 에서 `BadCredentialsException` 처리하는 메서드 추가
### **인증, 인가 예외**
- `JwtAuthenticationFilter` 의 기존 로직은 허용되지 않은 url 접속 시 TokenNotFoundException 을 리턴해주었습니다.
- SecurityConfig 에서 사용하지 않는 url은 denyAll()을 적용하였고 이는 `AccessDeniedException` 리턴합니다. 
- `AccessDeniedHandler` 로 `AccessDeniedException` 처리를 위임 받고 이를 다시 `ExceptionResponseHanlder` 로 넘겨 최종으로 예외 응답을 반환하도록 변경하였습니다.
- SecurityConfig 의 filterChain() 메서드에서 anonymous.disable() 을 사용하여 인증되지 않은 사용자나 인증은 되었지만 허용하지 않은 url 로 접근 시 `AccessDeniedException` 을 던지도록 설정하였습니다.
### **AccessToken 재발급 로직**
- AccessToken 이 만료되었을 때 서버는 토큰이 만료되었음을 알려준 후 클라이언트가 재발급 url 로 요청을 보내면 accessToken 과 refreshToken 을 사용하여 재발급 합니다.
- 이 때 AccessToken 이 만료되어 `JwtAuthenticationFilter` 를 통과하지 못하고 예외를 던지는 상황이 발생하였습니다.
- `JwtTokenProvider`-`validateToken()` 에서 `ExpiredJwtException` 을 던지면 url 이 재발급 url 인지 확인 후 예외를 던지지 않도록 하는 로직을 필터에 추가하였습니다.